### PR TITLE
Updated BUILD.txt for Linux

### DIFF
--- a/BUILD.txt
+++ b/BUILD.txt
@@ -58,8 +58,18 @@ On Mac OS X it's located in:
 
 /Applications/Arduino.app/Contents/Resources/Java/hardware/arduino/sam
 
-2. You'll need to open the file in a text editor and find the line:
+On Linux, it's located in my home directory, downloaded and extracted from Arduino website, but must be installed.
 
+/home/m1geo/arduino-1.6.7/hardware/arduino/sam 
+
+  I (M1GEO) found it was necessary to download SAM-1.6.6 outside of the Arduino IDE, and manually extract the files. 
+  The Board Manager didn't seem to install the SAM files correctly. Here's how I did it:
+  
+  a) wget http://downloads.arduino.cc/cores/sam-1.6.6.tar.bz2 -O /tmp/sam-1.6.6.tar.bz2 (download and save in /tmp)
+  b) cd arduino-1.6.7/hardware/arduino/ (Arduino root, here, in my home directory)
+  c) tar xvfj /tmp/sam-1.6.6.tar.bz2
+
+2. You'll need to open the file in a text editor and find the line:
 
 ## Combine gc-sections, archives, and objects
 recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" -mcpu={build.mcu} -mthumb {compiler.c.elf.flags} "-T{build.variant.path}/{build.ldscript}" "-Wl,-Map,{build.path}/{build.project_name}.map" {compiler.c.elf.extra_flags} -o "{build.path}/{build.project_name}.elf" "-L{build.path}" -Wl,--cref -Wl,--check-sections -Wl,--gc-sections -Wl,--entry=Reset_Handler -Wl,--unresolved-symbols=report-all -Wl,--warn-common -Wl,--warn-section-align -Wl,--start-group "{build.path}/core/syscalls_sam3.c.o" {object_files} "{build.variant.path}/{build.variant_system_lib}" "{build.path}/{archive_file}" -Wl,--end-group -lm -gcc
@@ -68,7 +78,6 @@ In my version it's line 73.
 
 3. Modify it to read as follows:
 
-
 ## Combine gc-sections, archives, and objects
 recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" -mcpu={build.mcu} -mthumb {compiler.c.elf.flags} "-T{build.variant.path}/{build.ldscript}" "-Wl,-Map,{build.path}/{build.project_name}.map" {compiler.c.elf.extra_flags} -o "{build.path}/{build.project_name}.elf" "-L{build.path}" -Wl,--cref -Wl,--check-sections -Wl,--gc-sections -Wl,--entry=Reset_Handler -Wl,--unresolved-symbols=report-all -Wl,--warn-common -Wl,--warn-section-align -Wl,--start-group "{build.path}/core/syscalls_sam3.c.o" {object_files} "{build.variant.path}/{build.variant_system_lib}" "{build.system.path}/CMSIS/CMSIS/Lib/ARM/arm_cortexM3l_math.lib" "{build.path}/{archive_file}" -Wl,--end-group -lm -gcc
 
@@ -76,15 +85,10 @@ The change is near the end, and is the addition of:
 
 "{build.system.path}/CMSIS/CMSIS/Lib/ARM/arm_cortexM3l_math.lib"
 
+On Linux, the path was found to differ slightly (GCC instead of ARM):
+
+"{build.system.path}/CMSIS/CMSIS/Lib/GCC/arm_cortexM3l_math.lib"
+
 Which is the CMSIS AMR3 DSP library for little-endian operation.
 
 4. Save the file and start up the Arduino GUI and build MMDVM.
-
-I would like to get instructions for doing the same on a Linux platform. As a
-starter find the relevent platform.txt and try adding:
-
-"{build.system.path}/CMSIS/CMSIS/Lib/ARM/libarm_cortexM3l_math.a"
-
-or maybe:
-
-"{build.variant.path}/libarm_cortexM3l_math.a"


### PR DESCRIPTION
Updated with Linux information tested on Ubuntu.

Had to install sam-1.6.6 myself, download from ttp://downloads.arduino.cc/cores/sam-1.6.6.tar.bz2 and extract to arduino-1.6.7/hardware/arduino/
Modify platform.txt as with Windows/OSX, but path changes slightly from ARM to GCC: "{build.system.path}/CMSIS/CMSIS/Lib/GCC/libarm_cortexM3l_math.a"