### PR TITLE
Add new Mode for DMR Deviation Calibration.

### DIFF
--- a/CalDMR.cpp
+++ b/CalDMR.cpp
@@ -1,0 +1,55 @@
+/*
+ *   Copyright (C) 2009-2015 by Jonathan Naylor G4KLX
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include "Config.h"
+#include "Globals.h"
+#include "CalDMR.h"
+
+
+CCalDMR::CCalDMR() :
+m_transmit(false) 
+{
+}
+
+
+void CCalDMR::process()
+{
+ if (m_transmit)
+  {
+  dmrTX.setCal(true);
+  dmrTX.process();
+  }
+ else
+  {
+  dmrTX.setCal(false);
+  return;
+  }
+
+}
+
+
+uint8_t CCalDMR::write(const uint8_t* data, uint8_t length)
+{
+  if (length != 1U)
+    return 4U;
+
+  m_transmit = data[0U] == 1U;
+  return 0U;
+}
+ 
+

--- a/CalDMR.h
+++ b/CalDMR.h
@@ -1,0 +1,36 @@
+/*
+ *   Copyright (C) 2009-2015 by Jonathan Naylor G4KLX
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#if !defined(CALDMR_H)
+#define  CALDMR_H
+
+#include "Config.h"
+#include "DMRDefines.h"
+
+class CCalDMR {
+public:
+  CCalDMR();
+  void process();
+  uint8_t write(const uint8_t* data, uint8_t length);
+
+private:
+  bool      m_transmit;
+
+};
+
+#endif

--- a/DMRTX.cpp
+++ b/DMRTX.cpp
@@ -96,6 +96,10 @@ void CDMRTX::process()
         createData(1U);
         m_state = DMRTXSTATE_CACH1;
         break;
+
+      case DMRTXSTATE_CAL:
+        createCal();
+        break;
         
       default:
         createCACH(0U, 1U);
@@ -192,6 +196,15 @@ void CDMRTX::setStart(bool start)
   m_count = 0U;
 }
 
+void CDMRTX::setCal(bool start)
+{
+  m_state = start ? DMRTXSTATE_CAL : DMRTXSTATE_IDLE;
+
+  m_count = 0U;
+}
+
+
+
 void CDMRTX::writeByte(uint8_t c, uint8_t control)
 {
   q15_t inBuffer[DMR_RADIO_SYMBOL_LENGTH * 4U + 1U];
@@ -274,6 +287,17 @@ void CDMRTX::createData(uint8_t slotIndex)
     }
   }
 
+  m_poLen = DMR_FRAME_LENGTH_BYTES;
+  m_poPtr = 0U;
+}
+
+void CDMRTX::createCal()
+{
+    for (unsigned int i = 0U; i < DMR_FRAME_LENGTH_BYTES; i++) {
+      m_poBuffer[i]   = 0x5F;             //+3+3-3-3 pattern for deviation cal. 
+      m_markBuffer[i] = MARK_NONE;
+    }
+    
   m_poLen = DMR_FRAME_LENGTH_BYTES;
   m_poPtr = 0U;
 }

--- a/DMRTX.h
+++ b/DMRTX.h
@@ -29,7 +29,8 @@ enum DMRTXSTATE {
   DMRTXSTATE_SLOT1,
   DMRTXSTATE_CACH1,
   DMRTXSTATE_SLOT2,
-  DMRTXSTATE_CACH2
+  DMRTXSTATE_CACH2,
+  DMRTXSTATE_CAL
 };
 
 class CDMRTX {
@@ -41,6 +42,7 @@ public:
   uint8_t writeShortLC(const uint8_t* data, uint8_t length);
 
   void setStart(bool start);
+  void setCal(bool start);
 
   void process();
 
@@ -66,6 +68,7 @@ private:
 
   void createData(uint8_t slotIndex);
   void createCACH(uint8_t txSlotIndex, uint8_t rxSlotIndex);
+  void createCal();
   void writeByte(uint8_t c, uint8_t control);
 };
 

--- a/Globals.h
+++ b/Globals.h
@@ -39,7 +39,9 @@ enum MMDVM_STATE {
   STATE_DSTAR     = 1,
   STATE_DMR       = 2,
   STATE_YSF       = 3,
+  STATE_DMRCAL    = 98,
   STATE_CALIBRATE = 99
+
 };
 
 #include "SerialPort.h"
@@ -52,6 +54,7 @@ enum MMDVM_STATE {
 #include "YSFTX.h"
 #include "CalRX.h"
 #include "CalTX.h"
+#include "CalDMR.h"
 #include "Debug.h"
 #include "IO.h"
 
@@ -87,6 +90,7 @@ extern CYSFTX ysfTX;
 
 extern CCalRX calRX;
 extern CCalTX calTX;
+extern CCalDMR calDMR;
 
 #endif
 

--- a/MMDVM.ino
+++ b/MMDVM.ino
@@ -43,6 +43,7 @@ CYSFTX     ysfTX;
 
 CCalRX     calRX;
 CCalTX     calTX;
+CCalDMR    calDMR;
 
 CSerialPort serial;
 CIO io;
@@ -70,5 +71,9 @@ void loop()
 
   if (m_modemState == STATE_CALIBRATE)
     calTX.process();
+    
+  if (m_modemState == STATE_DMRCAL)
+    calDMR.process();
+    
 }
 


### PR DESCRIPTION
Add new mode for DMR Deviation Calibration.
Using MMDVMCal a new keyboard command 'D' puts modem into DMR test mode. 
'd' returns to Dstar mode. 
As defined in ETSI TS102 361-1 para. 10.2.2.3 this allows DMR deviation to be set using conventional 
FM deviation meters. 
The DMR Tx stream is constantly fed with +3+3-3-3 which after filtering produces a 1200Hz sinewave. 
The deviation of this sinewave should be set to 2.749 Khz +-10%. 