### PR TITLE
Add information for MMDVM build on Ubuntu 14.04 with latest Arduino IDE

### DIFF
--- a/BUILD.txt
+++ b/BUILD.txt
@@ -99,3 +99,21 @@ On Linux, the path was found to differ slightly (GCC instead of ARM):
 Which is the CMSIS AMR3 DSP library for little-endian operation.
 
 4. Save the file and start up the Arduino GUI and build MMDVM.
+
+For Arduino 1.6.9 with SAM 1.6.8
+--------------------------------
+
+1. Locate platform.txt. On Ubuntu 14.04 LTS x86_64 OS it is in:
+
+/home/$user/.arduino15/packages/arduino/hardware/sam/1.6.8/
+
+2. Open the file in a text editor and change the line:
+
+## Combine gc-sections, archives, and objects
+recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" -mcpu={build.mcu} -mthumb {compiler.c.elf.flags} "-T{build.variant.path}/{build.ldscript}" "-Wl,-Map,{build.path}/{build.project_name}.map" {compiler.c.elf.extra_flags} -o "{build.path}/{build.project_name}.elf" "-L{build.path}" -Wl,--cref -Wl,--check-sections -Wl,--gc-sections -Wl,--entry=Reset_Handler -Wl,--unresolved-symbols=report-all -Wl,--warn-common -Wl,--warn-section-align -Wl,--start-group {compiler.combine.flags} {object_files} "{build.variant.path}/{build.variant_system_lib}" "{build.path}/{archive_file}" -Wl,--end-group -lm -gcc
+
+to
+
+recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" -mcpu={build.mcu} -mthumb {compiler.c.elf.flags} "-T{build.variant.path}/{build.ldscript}" "-Wl,-Map,{build.path}/{build.project_name}.map" {compiler.c.elf.extra_flags} -o "{build.path}/{build.project_name}.elf" "-L{build.path}" -Wl,--cref -Wl,--check-sections -Wl,--gc-sections -Wl,--entry=Reset_Handler -Wl,--unresolved-symbols=report-all -Wl,--warn-common -Wl,--warn-section-align -Wl,--start-group {compiler.combine.flags} {object_files} "{build.variant.path}/{build.variant_system_lib}" "{build.system.path}/CMSIS/CMSIS/Lib/GCC/libarm_cortexM3l_math.a" "{build.path}/{archive_file}" -Wl,--end-group -lm -gcc
+
+3. Save the file, open the Arduino IDE and build MMDVM


### PR DESCRIPTION
I added some information and the latest Arduino IDE. Maybe we should consider deletion of information about older Arduino IDE versions?