### PR TITLE
Add hint about if MMDVM was compiled with EXTERNAL_OSC

### DIFF
--- a/SerialPort.cpp
+++ b/SerialPort.cpp
@@ -61,7 +61,11 @@ const uint8_t MMDVM_DEBUG3       = 0xF3U;
 const uint8_t MMDVM_DEBUG4       = 0xF4U;
 const uint8_t MMDVM_DEBUG5       = 0xF5U;
 
+#if defined(EXTERNAL_OSC)
+const uint8_t HARDWARE[]         = "MMDVM 20160816 24kHz TCXO (D-Star/DMR/System Fusion/CW Id)";
+#else
 const uint8_t HARDWARE[]         = "MMDVM 20160816 24kHz (D-Star/DMR/System Fusion/CW Id)";
+#endif
 
 const uint8_t PROTOCOL_VERSION   = 1U;
 


### PR DESCRIPTION
I guess it might be helpful if the information coming from MMDVM during initialization contained a hint about if the firmware was compiled with external oscillator enabled.