### PR TITLE
Disable external TCXO by default

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -22,7 +22,7 @@
 // Allow for the use of high quality external clock oscillators
 // The number is the frequency of the oscillator in Hertz.
 // For 12 MHz
-#define EXTERNAL_OSC 12000000
+// #define EXTERNAL_OSC 12000000
 // For 14.4 MHz
 // #define EXTERNAL_OSC 14400000
 // For 19.2 MHz


### PR DESCRIPTION
Referencing the discussion in MMDVM Yahoo group under https://groups.yahoo.com/neo/groups/mmdvm/conversations/topics/8735
It seems that some people couldn't use MMDVM firmware because TCXO with 12MHz was enabled by default in commit f8d9c881. I guess this was an accident and the TCXO should be left defaulting to off.