### PR TITLE
Correct spaces in order to make mmdvmmenu.sh work (again)

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -40,13 +40,13 @@
 // #define ARDUINO_MODE_PINS
 
 // For the original Arduino Due pin layout
-// #define  ARDUINO_DUE_PAPA
+// #define ARDUINO_DUE_PAPA
 
 // For the ZUM V1.0 and V1.2 boards pin layout
-#define  ARDUINO_DUE_ZUM_V10_V12
+#define ARDUINO_DUE_ZUM_V10_V12
 
 // For the SP8NTH board
-// #define  ARDUINO_DUE_NTH
+// #define ARDUINO_DUE_NTH
 
 // To use wider C4FSK filters for DMR, System Fusion and P25 on transmit
 // #define WIDE_C4FSK_FILTERS_TX

--- a/mmdvmmenu.sh
+++ b/mmdvmmenu.sh
@@ -82,7 +82,7 @@ EOF
     "3")  sed -e 's/\/\/ #define EXTERNAL_OSC 19200000/#define EXTERNAL_OSC 19200000/'     $conf > $conf.tmp && mv -f $conf.tmp $conf && echo "19.2 MHz clock enabled";;
     "4")  sed -e 's/\/\/ #define USE_COS_AS_LOCKOUT /#define USE_COS_AS_LOCKOUT/'          $conf > $conf.tmp && mv -f $conf.tmp $conf && echo "COS as Lockout enabled";;
     "5")  sed -e 's/\/\/ #define ARDUINO_MODE_PINS/#define ARDUINO_MODE_PINS/'             $conf > $conf.tmp && mv -f $conf.tmp $conf && echo "Mode pins Enabled";;
-    "6")  sed -e 's/\/\/ #define ARDUINO_DUE_PAPA/#define  ARDUINO_DUE_PAPA/'              $conf > $conf.tmp && mv -f $conf.tmp $conf && echo "Layout for the PAPA board enabled";;
+    "6")  sed -e 's/\/\/ #define ARDUINO_DUE_PAPA/#define ARDUINO_DUE_PAPA/'               $conf > $conf.tmp && mv -f $conf.tmp $conf && echo "Layout for the PAPA board enabled";;
     "7")  sed -e 's/\/\/ #define ARDUINO_DUE_ZUM_V10_V12/#define ARDUINO_DUE_ZUM_V10_V12/' $conf > $conf.tmp && mv -f $conf.tmp $conf && echo "Layout for ZUM V1.0 and V1.2 boards enabled";;
     "8")  sed -e 's/\/\/ #define ARDUINO_DUE_NTH/#define ARDUINO_DUE_NTH/'                 $conf > $conf.tmp && mv -f $conf.tmp $conf && echo "Layout for SP8NTH board enabled";;
     "9")  sed -e 's/\/\/ #define SERIAL_REPEATER/#define SERIAL_REPEATER/'                 $conf > $conf.tmp && mv -f $conf.tmp $conf && echo "Modem display driver enabled";;


### PR DESCRIPTION
For some reason the defines for MMDVM board contain two spaces just before the board name. That break functionality of mmdvmmenu.sh
