### PR TITLE
Fix length of reported parameters

### DIFF
--- a/SerialPort.cpp
+++ b/SerialPort.cpp
@@ -116,7 +116,7 @@ void CSerialPort::getStatus()
 
   // Send all sorts of interesting internal values
   reply[0U]  = MMDVM_FRAME_START;
-  reply[1U]  = 10U;
+  reply[1U]  = 11U;
   reply[2U]  = MMDVM_GET_STATUS;
 
   reply[3U]  = 0x00U;


### PR DESCRIPTION
I have come to the conclusion that the getStatus() function reports incorrect length of reply array. The value was probably not aligned when P25 was added. Just stumbled across this while trying to debug a feature I was developing. Not a real big problem but it has taken me some time ... :-)