### PR TITLE
Add carrier detect LED to MMDVM firmware

### DIFF
--- a/Globals.h
+++ b/Globals.h
@@ -86,6 +86,7 @@ extern bool m_p25Enable;
 extern bool m_duplex;
 
 extern bool m_tx;
+extern bool m_dcd;
 
 extern uint32_t m_sampleCount;
 extern bool     m_sampleInsert;

--- a/IO.cpp
+++ b/IO.cpp
@@ -312,6 +312,11 @@ void CIO::setDecode(bool dcd)
   m_dcd = dcd;
 }
 
+bool CIO::getDecode()
+{
+  return m_dcd;
+}
+
 void CIO::setADCDetection(bool detect)
 {
   m_detect = detect;

--- a/IO.cpp
+++ b/IO.cpp
@@ -61,7 +61,6 @@ m_ysfTXLevel(128 * 128),
 m_p25TXLevel(128 * 128),
 m_ledCount(0U),
 m_ledValue(true),
-m_dcd(false),
 m_detect(false),
 m_adcOverflow(0U),
 m_dacOverflow(0U),
@@ -310,11 +309,6 @@ void CIO::setDecode(bool dcd)
     setCOSInt(dcd ? true : false);
 
   m_dcd = dcd;
-}
-
-bool CIO::getDecode()
-{
-  return m_dcd;
 }
 
 void CIO::setADCDetection(bool detect)

--- a/IO.h
+++ b/IO.h
@@ -78,7 +78,6 @@ private:
   uint32_t             m_ledCount;
   bool                 m_ledValue;
 
-  bool                 m_dcd;
   bool                 m_detect;
 
   uint16_t             m_adcOverflow;

--- a/IO.h
+++ b/IO.h
@@ -51,8 +51,6 @@ public:
 
   bool hasLockout() const;
 
-  bool getDecode();
-
   void resetWatchdog();
 
 private:

--- a/IO.h
+++ b/IO.h
@@ -51,6 +51,8 @@ public:
 
   bool hasLockout() const;
 
+  bool getDecode();
+
   void resetWatchdog();
 
 private:

--- a/MMDVM.cpp
+++ b/MMDVM.cpp
@@ -33,7 +33,8 @@ bool m_p25Enable   = true;
 
 bool m_duplex = true;
 
-bool m_tx = false;
+bool m_tx  = false;
+bool m_dcd = false;
 
 uint32_t m_sampleCount = 0U;
 bool    m_sampleInsert = false;

--- a/MMDVM.ino
+++ b/MMDVM.ino
@@ -30,7 +30,8 @@ bool m_p25Enable   = true;
 
 bool m_duplex = true;
 
-bool m_tx = false;
+bool m_tx  = false;
+bool m_dcd = false;
 
 uint32_t m_sampleCount = 0U;
 bool    m_sampleInsert = false;

--- a/SerialPort.cpp
+++ b/SerialPort.cpp
@@ -116,7 +116,7 @@ void CSerialPort::getStatus()
 
   // Send all sorts of interesting internal values
   reply[0U]  = MMDVM_FRAME_START;
-  reply[1U]  = 11U;
+  reply[1U]  = 12U;
   reply[2U]  = MMDVM_GET_STATUS;
 
   reply[3U]  = 0x00U;
@@ -180,7 +180,12 @@ void CSerialPort::getStatus()
   else
     reply[10U] = 0U;
 
-  writeInt(1U, reply, 11);
+  if (io.getDecode())
+    reply[11U] = 1U;
+  else
+    reply[11U] = 0U;
+
+  writeInt(1U, reply, 12);
 }
 
 void CSerialPort::getVersion()

--- a/SerialPort.cpp
+++ b/SerialPort.cpp
@@ -180,7 +180,7 @@ void CSerialPort::getStatus()
   else
     reply[10U] = 0U;
 
-  if (io.getDecode())
+  if (m_dcd)
     reply[11U] = 1U;
   else
     reply[11U] = 0U;


### PR DESCRIPTION
Added one more LED to let the UMP be able  to signalize when MMDVMHost detected a valid carrier. The information is hooked from the MMDVM CD function that also drives the ZUM onboard LED.