### PR TITLE
Change ADC1 to reduce number of interrupts.

### DIFF
--- a/IOTeensy.cpp
+++ b/IOTeensy.cpp
@@ -117,7 +117,6 @@ void CIO::startInt()
   sum1 = (sum1 / 2U) | 0x8000U;
   ADC1_PG    = sum1;
 
-  NVIC_ENABLE_IRQ(IRQ_ADC1);
 #endif
 
 #if defined(EXTERNAL_OSC)
@@ -162,25 +161,30 @@ void CIO::interrupt(uint8_t source)
     if ((ADC0_SC1A & ADC_SC1_COCO) == ADC_SC1_COCO) {
       sample = ADC0_RA;
       m_rxBuffer.put(sample, control);
-
-#if defined(SEND_RSSI_DATA)
-      ADC1_SC1A  = ADC_SC1_AIEN | PIN_RSSI;
-#else
-      m_rssiBuffer.put(0U);
-#endif
     }
-
-    m_watchdog++;
-  }
-
+    
 #if defined(SEND_RSSI_DATA)
-  if (source == 1U) {  // ADC1
+ 
     if ((ADC1_SC1A & ADC_SC1_COCO) == ADC_SC1_COCO) {
       uint16_t rssi = ADC1_RA;
       m_rssiBuffer.put(rssi);
     }
-  }
+    else {
+      m_rssiBuffer.put(0U);
+    }
+    ADC1_SC1A  = ADC_SC1_AIEN | PIN_RSSI;             //start the next RSSI conversion
+
+#else
+      m_rssiBuffer.put(0U);
 #endif
+  
+
+    m_watchdog++;
+  }
+
+
+
+
 }
 
 bool CIO::getCOSInt()


### PR DESCRIPTION
Disable interrupts for ADC1. 
Every time ADC0 interrupts (24Khz) read the current conversion from ADC1 and software trigger a new one. 
This way there will always be an ADC1 conversion available whenever ADC0 interrupts.