### PR TITLE
Dont compile STM32F1 stuff for STM32F4 target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ else ifdef SystemRoot
 else
 	ASOURCES=$(shell find . -name '*.s')
 	CSOURCES=$(shell find . -name '*.c')
+	CSOURCES:=$(filter-out $(wildcard ./system_stm32f1xx/*.c), $(CSOURCES))
 	CXXSOURCES=$(shell find . -name '*.cpp')
 	CLEANCMD=rm -f $(OBJECTS) $(BINDIR)/$(BINELF) $(BINDIR)/$(BINHEX) $(BINDIR)/$(BINBIN)
 	MDBIN=mkdir $@

--- a/Makefile
+++ b/Makefile
@@ -35,19 +35,21 @@ BINDIR=bin
 ifdef SYSTEMROOT
 	ASOURCES=$(shell dir /S /B *.s)
 	CSOURCES=$(shell dir /S /B *.c)
+	CSOURCES:=$(foreach a,$(CSOURCES),$(if $(findstring stm32f1xx,$a),,$a))
 	CXXSOURCES=$(shell dir /S /B *.cpp)
 	CLEANCMD=del /S *.o *.hex *.bin *.elf
 	MDBIN=md $@
 else ifdef SystemRoot
 	ASOURCES=$(shell dir /S /B *.s)
 	CSOURCES=$(shell dir /S /B *.c)
+	CSOURCES:=$(foreach a,$(CSOURCES),$(if $(findstring stm32f1xx,$a),,$a))
 	CXXSOURCES=$(shell dir /S /B *.cpp)
 	CLEANCMD=del /S *.o *.hex *.bin *.elf
 	MDBIN=md $@
 else
 	ASOURCES=$(shell find . -name '*.s')
 	CSOURCES=$(shell find . -name '*.c')
-	CSOURCES:=$(filter-out $(wildcard ./system_stm32f1xx/*.c), $(CSOURCES))
+	CSOURCES:=$(foreach a,$(CSOURCES),$(if $(findstring stm32f1xx,$a),,$a))
 	CXXSOURCES=$(shell find . -name '*.cpp')
 	CLEANCMD=rm -f $(OBJECTS) $(BINDIR)/$(BINELF) $(BINDIR)/$(BINHEX) $(BINDIR)/$(BINBIN)
 	MDBIN=mkdir $@


### PR DESCRIPTION
The make command for nucleo boards compiles all .c files. As the stm32f1 lib seems incomplete and is not needed at all for STM32F4 compilations just ignore the stm32f1xx directory.