### PR TITLE
Include Git ID in Modem description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 obj/
 bin/
 STM32F4XX_Lib/
+GitVersion.h

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,7 @@ pi: CXXFLAGS+=$(DEFS_PI) -Os -fno-exceptions -ffunction-sections -fdata-sections
 pi: LDFLAGS+=-Os --specs=nano.specs
 pi: release
 
+nucleo: GitVersion.h
 nucleo: CFLAGS+=$(DEFS_NUCLEO) -Os -ffunction-sections -fdata-sections -fno-builtin -Wno-implicit -DCUSTOM_NEW -DNO_EXCEPTIONS
 nucleo: CXXFLAGS+=$(DEFS_NUCLEO) -Os -fno-exceptions -ffunction-sections -fdata-sections -fno-builtin -fno-rtti -DCUSTOM_NEW -DNO_EXCEPTIONS
 nucleo: LDFLAGS+=-Os --specs=nano.specs
@@ -175,7 +176,7 @@ endif
 # Export the current git version if the index file exists, else 000...
 GitVersion.h:
 ifneq ("$(wildcard .git/index)","")
-	echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > $@
+	echo "#define GITVERSION \"$(shell git rev-parse --short HEAD)\"" > $@
 else
-	echo "const char *gitversion = \"0000000000000000000000000000000000000000\";" > $@
+	echo "#define GITVERSION \"0000000\"" > $@
 endif

--- a/Makefile
+++ b/Makefile
@@ -36,19 +36,19 @@ ifdef SYSTEMROOT
 	ASOURCES=$(shell dir /S /B *.s)
 	CSOURCES=$(shell dir /S /B *.c)
 	CXXSOURCES=$(shell dir /S /B *.cpp)
-	CLEANCMD=del /S *.o *.hex *.bin *.elf
+	CLEANCMD=del /S *.o *.hex *.bin *.elf GitVersion.h
 	MDBIN=md $@
 else ifdef SystemRoot
 	ASOURCES=$(shell dir /S /B *.s)
 	CSOURCES=$(shell dir /S /B *.c)
 	CXXSOURCES=$(shell dir /S /B *.cpp)
-	CLEANCMD=del /S *.o *.hex *.bin *.elf
+	CLEANCMD=del /S *.o *.hex *.bin *.elf GitVersion.h
 	MDBIN=md $@
 else
 	ASOURCES=$(shell find . -name '*.s')
 	CSOURCES=$(shell find . -name '*.c')
 	CXXSOURCES=$(shell find . -name '*.cpp')
-	CLEANCMD=rm -f $(OBJECTS) $(BINDIR)/$(BINELF) $(BINDIR)/$(BINHEX) $(BINDIR)/$(BINBIN)
+	CLEANCMD=rm -f $(OBJECTS) $(BINDIR)/$(BINELF) $(BINDIR)/$(BINHEX) $(BINDIR)/$(BINBIN) GitVersion.h
 	MDBIN=mkdir $@
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -171,3 +171,11 @@ endif
 ifneq ($(wildcard /opt/openocd/bin/openocd),)
 	/opt/openocd/bin/openocd -f /opt/openocd/share/openocd/scripts/board/stm32f4discovery.cfg -c "program bin/$(BINELF) verify reset exit"
 endif
+
+# Export the current git version if the index file exists, else 000...
+GitVersion.h:
+ifneq ("$(wildcard .git/index)","")
+	echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > $@
+else
+	echo "const char *gitversion = \"0000000000000000000000000000000000000000\";" > $@
+endif

--- a/SerialPort.cpp
+++ b/SerialPort.cpp
@@ -22,6 +22,11 @@
 #include "Config.h"
 #include "Globals.h"
 
+#if defined(STM32F4XX) || defined(STM32F4)
+#include "GitVersion.h"
+#endif
+
+
 #include "SerialPort.h"
 
 const uint8_t MMDVM_FRAME_START  = 0xE0U;
@@ -74,8 +79,14 @@ const uint8_t MMDVM_DEBUG5       = 0xF5U;
 #else
 #define DESCRIPTION              "MMDVM 20170406 (D-Star/DMR/System Fusion/P25/RSSI/CW Id)"
 #endif
+
+#if defined(GITVERSION)
+#define concat(a, b) a " GitID #"b""
+const char HARDWARE[] = concat(DESCRIPTION, GITVERSION);
+#else
 #define concat(a, b, c) a " (Build: " b " " c ")"
 const char HARDWARE[] = concat(DESCRIPTION, __TIME__, __DATE__);
+#endif
 
 const uint8_t PROTOCOL_VERSION   = 1U;
 


### PR DESCRIPTION
At least for MMDVMs built via Makefile (e.g. STM32F446RE nucleo board) include the GitID of the running firmware.