### PR TITLE
Remove Arduino compiler warning

### DIFF
--- a/SerialPort.cpp
+++ b/SerialPort.cpp
@@ -81,7 +81,7 @@ const uint8_t MMDVM_DEBUG5       = 0xF5U;
 #endif
 
 #if defined(GITVERSION)
-#define concat(a, b) a " GitID #"b""
+#define concat(a, b) a " GitID #" b ""
 const char HARDWARE[] = concat(DESCRIPTION, GITVERSION);
 #else
 #define concat(a, b, c) a " (Build: " b " " c ")"


### PR DESCRIPTION
Fixes a warning while using the original Arduino IDE:

![screenshot from 2017-04-13 09-43-04](https://cloud.githubusercontent.com/assets/7112907/24995101/c72e458e-202d-11e7-8eda-3a5b66854603.png)
