### PR TITLE
Make Makefile compatible with builds on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,8 +188,14 @@ endif
 
 # Export the current git version if the index file exists, else 000...
 GitVersion.h:
+ifdef SYSTEMROOT
+	echo #define GITVERSION "0000000" > $@
+else ifdef SystemRoot
+	echo #define GITVERSION "0000000" > $@
+else
 ifneq ("$(wildcard .git/index)","")
 	echo "#define GITVERSION \"$(shell git rev-parse --short HEAD)\"" > $@
 else
 	echo "#define GITVERSION \"0000000\"" > $@
+endif
 endif


### PR DESCRIPTION
According to the discussion in MMDVM Yahoo group, my last commits broke Windows builds.
This should fix it. Feedback welcome.