### PR TITLE
Fix undefined reference

### DIFF
--- a/IOSTM_CMSIS.cpp
+++ b/IOSTM_CMSIS.cpp
@@ -415,4 +415,9 @@ void CIO::setP25Int(bool on)
   BB_P25 = !!on;
 }
 
+void CIO::delayInt(unsigned int dly)
+{
+  delay(dly);
+}
+
 #endif


### PR DESCRIPTION
Fix undefined reference to `CIO::delayInt(unsigned int)' for LED test