### PR TITLE
Constant Service LED

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -69,4 +69,8 @@
 // To reduce CPU load, you can remove the DC blocker by commenting out the next line
 #define USE_DCBLOCKER
 
+// Constant Service LED once repeater is running 
+// Do not use if employing an external hardware watchdog 
+// #define CONSTANT_SRV_LED
+
 #endif

--- a/IO.cpp
+++ b/IO.cpp
@@ -255,11 +255,15 @@ void CIO::process()
       m_watchdog = 0U;
     }
 
+#if defined(CONSTANT_SRV_LED)
+    setLEDInt(true);
+#else
     if (m_ledCount >= 24000U) {
       m_ledCount = 0U;
       m_ledValue = !m_ledValue;
       setLEDInt(m_ledValue);
     }
+#endif
   } else {
     if (m_ledCount >= 240000U) {
       m_ledCount = 0U;


### PR DESCRIPTION
Adds a compile time option in Config.h  to make the service LED constant as opposed to rapidly blinking.

Adds a note to Config.h to say not to use this if using an external hardware watchdog.