### PR TITLE
CTCSS threshold is level agnostic

### DIFF
--- a/FMCTCSSRX.cpp
+++ b/FMCTCSSRX.cpp
@@ -109,7 +109,6 @@ uint8_t CFMCTCSSRX::setParams(uint8_t frequency, uint8_t threshold)
   return 0U;
 }
 
-char bla[256];
 CTCSSState CFMCTCSSRX::process(q15_t sample)
 {
   m_result = m_result & (~CTS_READY);
@@ -154,13 +153,16 @@ CTCSSState CFMCTCSSRX::process(q15_t sample)
 
     // value = m_q0 * m_q0 + m_q1 * m_q1 - m_q0 * m_q1 * m_coeffDivTwo * 2
     q31_t value = t2 + t4 - t9;
-    sprintf(bla, "CTCSS Value / Threshold %d %d", value, m_threshold);
-    DEBUG1(bla);
+
+    bool previousCTCSSValid = CTCSS_VALID(m_result);
     m_result = m_result | CTS_READY;
     if (value >= m_threshold)
       m_result = m_result | CTS_VALID;
     else
       m_result = m_result & ~CTS_VALID;
+
+    if(previousCTCSSValid != CTCSS_VALID(m_result))
+      DEBUG4("CTCSS Value / Threshold / Valid", value, m_threshold, CTCSS_VALID(m_result));
 
     m_count = 0U;
     m_q0 = 0;

--- a/IO.cpp
+++ b/IO.cpp
@@ -592,3 +592,8 @@ bool CIO::hasLockout() const
 {
   return m_lockout;
 }
+
+q15_t CIO::getRxLevel() const
+{
+  return m_rxLevel;
+}

--- a/IO.h
+++ b/IO.h
@@ -56,6 +56,8 @@ public:
   
   void selfTest();
 
+  q15_t getRxLevel() const;
+
 private:
   bool                 m_started;
 


### PR DESCRIPTION
CTCSS Thresold now RX level independent, however larger values are needed in the config. E.g. I had 30 and needed 80 with this change.