### PR TITLE
Make the FM chain RX Level independant

### DIFF
--- a/FM.cpp
+++ b/FM.cpp
@@ -40,8 +40,6 @@ m_hangTimer(),
 m_filterStage1(  724,   1448,   724, 32768, -37895, 21352),//3rd order Cheby Filter 300 to 2700Hz, 0.2dB passband ripple, sampling rate 24kHz
 m_filterStage2(32768,      0,-32768, 32768, -50339, 19052),
 m_filterStage3(32768, -65536, 32768, 32768, -64075, 31460),
-m_preemphasis(32768,  13967, 0, 32768, -18801, 0),//75µS 24kHz sampling rate
-m_deemphasis (32768, -18801, 0, 32768,  13967, 0),//75µS 24kHz sampling rate
 m_blanking(),
 m_useCOS(true),
 m_cosInvert(false),
@@ -92,8 +90,7 @@ void CFM::samples(bool cos, q15_t* samples, uint8_t length)
     }
 
     // Only let audio through when relaying audio
-    if (m_state == FS_RELAYING || m_state == FS_KERCHUNK) {    
-      // currentSample = m_deemphasis.filter(currentSample);
+    if (m_state == FS_RELAYING || m_state == FS_KERCHUNK) {  
       // m_downsampler.addSample(currentSample);
       currentSample = m_blanking.process(currentSample);
       currentSample *= m_rfAudioBoost;
@@ -115,8 +112,6 @@ void CFM::samples(bool cos, q15_t* samples, uint8_t length)
       currentSample += m_timeoutTone.getAudio();
 
     currentSample = m_filterStage3.filter(m_filterStage2.filter(m_filterStage1.filter(currentSample)));
-
-    // currentSample = m_preemphasis.filter(currentSample);
 
     currentSample += m_ctcssTX.getAudio();
 

--- a/FM.h
+++ b/FM.h
@@ -77,8 +77,6 @@ private:
   CFMDirectFormI       m_filterStage1;
   CFMDirectFormI       m_filterStage2;
   CFMDirectFormI       m_filterStage3;
-  CFMDirectFormI       m_preemphasis;
-  CFMDirectFormI       m_deemphasis;
   CFMBlanking          m_blanking;
   bool                 m_useCOS;
   bool                 m_cosInvert;

--- a/FM.h
+++ b/FM.h
@@ -84,6 +84,7 @@ private:
   bool                 m_cosInvert;
   q15_t                m_rfAudioBoost;
   CFMDownsampler       m_downsampler;
+  q15_t                m_rxLevel;
 
   void stateMachine(bool validSignal);
   void listeningState(bool validSignal);

--- a/FMCTCSSRX.h
+++ b/FMCTCSSRX.h
@@ -34,7 +34,7 @@ class CFMCTCSSRX {
 public:
   CFMCTCSSRX();
 
-  uint8_t setParams(uint8_t frequency, uint8_t threshold, uint8_t level);
+  uint8_t setParams(uint8_t frequency, uint8_t threshold);
   
   uint8_t process(q15_t sample);
 
@@ -47,9 +47,6 @@ private:
   q31_t    m_q0;
   q31_t    m_q1;
   uint8_t  m_result;
-  q15_t    m_rxLevelInverse;
-
-  q15_t q15Division(q15_t a, q15_t divisor);
 };
 
 #endif


### PR DESCRIPTION
This uses division as implementing binary longdivision would have involved lots of loops and conditions.
ARM-v7M has  [hardware divsion](https://developer.arm.com/ip-products/processors/cortex-m/cortex-m3)