### PR TITLE
Fix led alternate macro names

### DIFF
--- a/IOSTM.cpp
+++ b/IOSTM.cpp
@@ -426,7 +426,7 @@ void CIO::setNXDNInt(bool on)
 void CIO::setPOCSAGInt(bool on)
 {
 #if defined(MODE_LEDS)
-#if defined(USE_ALTERNATE_FM_LEDS)
+#if defined(USE_ALTERNATE_POCSAG_LEDS)
    GPIO_WriteBit(PORT_DSTAR, PIN_DSTAR, on ? Bit_SET : Bit_RESET);
    GPIO_WriteBit(PORT_DMR,   PIN_DMR,   on ? Bit_SET : Bit_RESET);
 #else
@@ -435,7 +435,7 @@ void CIO::setPOCSAGInt(bool on)
 #endif
 
 #if defined(MODE_PINS) && defined(STM32F4_NUCLEO_MORPHO_HEADER) && (defined(STM32F4_NUCLEO) || defined(STM32F722_RPT_HAT))
-#if defined(USE_ALTERNATE_FM_LEDS)
+#if defined(USE_ALTERNATE_POCSAG_LEDS)
    GPIO_WriteBit(PORT_MDSTAR, PIN_MDSTAR, on ? Bit_SET : Bit_RESET);
    GPIO_WriteBit(PORT_MDMR,   PIN_MDMR,   on ? Bit_SET : Bit_RESET);
 #else

--- a/IOSTM.cpp
+++ b/IOSTM.cpp
@@ -113,6 +113,15 @@ void CIO::initInt()
    GPIO_InitStruct.GPIO_Mode  = GPIO_Mode_OUT;
    GPIO_Init(PORT_POCSAG, &GPIO_InitStruct);
 #endif
+
+#if !defined(USE_ALTERNATE_FM_LEDS)
+   // FM pin
+   RCC_AHB1PeriphClockCmd(RCC_Per_FM, ENABLE);
+   GPIO_InitStruct.GPIO_Pin   = PIN_FM;
+   GPIO_InitStruct.GPIO_Mode  = GPIO_Mode_OUT;
+   GPIO_Init(PORT_FM, &GPIO_InitStruct);
+#endif
+
 #endif
 
 #if defined(MODE_PINS) && defined(STM32F4_NUCLEO_MORPHO_HEADER) && (defined(STM32F4_NUCLEO) || defined(STM32F722_RPT_HAT))
@@ -155,6 +164,15 @@ void CIO::initInt()
    GPIO_InitStruct.GPIO_Mode  = GPIO_Mode_OUT;
    GPIO_Init(PORT_MPOCSAG, &GPIO_InitStruct);
 #endif
+
+#if !defined(USE_ALTERNATE_FM_LEDS)
+   // FM mode pin
+   RCC_AHB1PeriphClockCmd(RCC_Per_MFM, ENABLE);
+   GPIO_InitStruct.GPIO_Pin   = PIN_MFM;
+   GPIO_InitStruct.GPIO_Mode  = GPIO_Mode_OUT;
+   GPIO_Init(PORT_MFM, &GPIO_InitStruct);
+#endif
+
 #endif
 }
 


### PR DESCRIPTION
Also adds the missing FM led/mode GPIO init code.  Currently only the "MMDVM_RPT_Hat Pi-Hat F0DEI DB9MAT DF2ET board" supports dedicated FM led/mode pins.