### PR TITLE
Speed improvements and fixes for FM Ext

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -35,6 +35,9 @@
 // For 19.2 MHz
 // #define EXTERNAL_OSC 19200000
 
+// Use a higher baudrate for host communication. Required for FM network !
+// #define SERIAL_SPEED 230400
+
 // Allow the use of the COS line to lockout the modem
 // #define USE_COS_AS_LOCKOUT
 

--- a/Config.h
+++ b/Config.h
@@ -36,7 +36,9 @@
 // #define EXTERNAL_OSC 19200000
 
 // Use a higher baudrate for host communication. Required for FM network !
-// #define SERIAL_SPEED 230400
+#define SERIAL_SPEED 115200 //suitable for most older boards (Arduino, Due STM32F1_POG etc). External FM will NOT work with this !
+// #define SERIAL_SPEED 230400 //Only works on newer board M4, M7, Teensy. External FM will works with this
+// #define SERIAL_SPEED 460800 // Experimantal
 
 // Allow the use of the COS line to lockout the modem
 // #define USE_COS_AS_LOCKOUT

--- a/FM.cpp
+++ b/FM.cpp
@@ -153,7 +153,8 @@ void CFM::process()
   uint16_t space = io.getSpace();
   uint16_t length = m_outputRFRB.getData();
 
-  if (space > FM_TX_BLOCK_SIZE && length >= FM_TX_BLOCK_SIZE ) {
+  if (space > 10U && length >= FM_TX_BLOCK_SIZE ) {
+    space -= 2U;
     if (length > FM_TX_BLOCK_SIZE)
       length = FM_TX_BLOCK_SIZE;
     if (space > FM_TX_BLOCK_SIZE)

--- a/FMDirectForm1.h
+++ b/FMDirectForm1.h
@@ -29,7 +29,7 @@ THE SOFTWARE.
 
 // based on https://raw.githubusercontent.com/berndporr/iir_fixed_point/master/DirectFormI.h
 
-#include "Globals.h"
+#include <cstdint>
 
 #ifndef DIRECTFORMI_H_
 #define DIRECTFORMI_H_

--- a/FMDownsampler.cpp
+++ b/FMDownsampler.cpp
@@ -20,7 +20,6 @@
 #include "Config.h"
 #include "FMDownsampler.h"
 
-
 CFMDownsampler::CFMDownsampler(uint16_t length) :
 m_ringBuffer(length),
 m_samplePack(0U),
@@ -32,17 +31,17 @@ m_sampleIndex(0U)
 
 void CFMDownsampler::addSample(q15_t sample)
 {
-  uint16_t usample = uint16_t(sample + 2048);
+  uint32_t usample = uint32_t(int32_t(sample) + 2048);
   //only take one of three samples
   switch(m_sampleIndex){
     case 0:
-      m_samplePack = uint32_t(usample) << 12;
+      m_samplePack = usample << 12;
     break;
     case 3:{
-      m_samplePack |= uint32_t(usample);
+      m_samplePack |= usample;
       
       //we did not use MSB; skip it
-      TSamplePairPack pair{m_samplePackPointer[1U], m_samplePackPointer[2U], m_samplePackPointer[3U]}; 
+      TSamplePairPack pair{m_samplePackPointer[0U], m_samplePackPointer[1U], m_samplePackPointer[2U]}; 
 
       m_ringBuffer.put(pair);
 

--- a/FMDownsampler.h
+++ b/FMDownsampler.h
@@ -23,6 +23,7 @@
 #include "Config.h"
 #include "RingBuffer.h"
 #include "FMSamplePairPack.h"
+#include "FMDirectForm1.h"
 
 class CFMDownsampler {
 public:
@@ -34,11 +35,9 @@ public:
 
 private:
   CRingBuffer<TSamplePairPack> m_ringBuffer;
-
-  uint32_t m_samplePack;
-  uint8_t *m_samplePackPointer;
-
-  uint8_t m_sampleIndex;
+  uint32_t                     m_samplePack;
+  uint8_t*                     m_samplePackPointer;
+  uint8_t                      m_sampleIndex;
 };
 
 #endif

--- a/FMDownsampler.h
+++ b/FMDownsampler.h
@@ -23,7 +23,6 @@
 #include "Config.h"
 #include "RingBuffer.h"
 #include "FMSamplePairPack.h"
-#include "FMDirectForm1.h"
 
 class CFMDownsampler {
 public:

--- a/FMUpSampler.cpp
+++ b/FMUpSampler.cpp
@@ -52,9 +52,9 @@ void CFMUpSampler::addData(const uint8_t* data, uint16_t length)
         uint32_t pack = 0U;
         uint8_t* packPtr = (uint8_t*)&pack;
 
-        packPtr[1] = m_pack.byte0;
-        packPtr[2] = m_pack.byte1;
-        packPtr[3] = m_pack.byte2;
+        packPtr[0U] = m_pack.byte0;
+        packPtr[1U] = m_pack.byte1;
+        packPtr[2U] = m_pack.byte2;
 
         q15_t sample2 = q15_t(uint16_t(pack & FM_UPSAMPLE_MASK) - 2048);
         q15_t sample1 = q15_t(uint16_t(pack >> 12) - 2048);

--- a/STMUART.cpp
+++ b/STMUART.cpp
@@ -1,0 +1,100 @@
+/*
+ *   Copyright (c) 2020 by Jonathan Naylor G4KLX
+ *   Copyright (c) 2020 by Geoffrey Merck F4FXL - KC3FRA   
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#if defined(STM32F4XX) || defined(STM32F7XX)
+
+#include "STMUART.h"
+
+CSTMUART::CSTMUART() :
+m_usart(NULL)
+{
+
+}
+
+void CSTMUART::init(USART_TypeDef* usart)
+{
+  m_usart = usart;
+}
+
+void CSTMUART::write(const uint8_t * data, uint16_t length)
+{
+  if(length == 0U || m_usart == NULL)
+    return;
+
+
+  m_txFifo.put(data[0]);
+  USART_ITConfig(m_usart, USART_IT_TXE, ENABLE);//switch TX IRQ is on
+
+  for(uint16_t i = 1U; i < length; i++) {
+    m_txFifo.put(data[i]);
+  }
+
+  USART_ITConfig(m_usart, USART_IT_TXE, ENABLE);//make sure TX IRQ is on
+}
+
+uint8_t CSTMUART::read()
+{
+  return m_rxFifo.get();
+}
+
+void CSTMUART::handleIRQ()
+{
+  if(m_usart == NULL)
+    return;
+
+  if (USART_GetITStatus(m_usart, USART_IT_RXNE)) {
+    if(!m_rxFifo.isFull())
+      m_rxFifo.put((uint8_t) USART_ReceiveData(m_usart));
+    USART_ClearITPendingBit(USART1, USART_IT_RXNE);
+  }
+
+  if (USART_GetITStatus(m_usart, USART_IT_TXE)) {
+    if(!m_txFifo.isEmpty())
+      USART_SendData(m_usart, m_txFifo.get());
+
+    USART_ClearITPendingBit(m_usart, USART_IT_TXE);
+
+    if (m_txFifo.isEmpty()) // if there's no more data to transmit then turn off TX interrupts
+      USART_ITConfig(m_usart, USART_IT_TXE, DISABLE);
+  }
+}
+
+  // Flushes the transmit shift register
+// warning: this call is blocking
+void CSTMUART::flush()
+{
+  if(m_usart == NULL)
+    return;
+
+   // wait until the TXE shows the shift register is empty
+   while (USART_GetITStatus(m_usart, USART_FLAG_TXE))
+      ;
+}
+
+uint16_t CSTMUART::available()
+{
+  return m_rxFifo.isEmpty() ? 0U : 1U;
+}
+
+uint16_t CSTMUART::availableForWrite()
+{
+  return m_txFifo.isFull() ? 0U : 1U;
+}
+
+#endif

--- a/STMUART.h
+++ b/STMUART.h
@@ -1,0 +1,91 @@
+/*
+ *   Copyright (c) 2020 by Jonathan Naylor G4KLX
+ *   Copyright (c) 2020 by Geoffrey Merck F4FXL - KC3FRA   
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#if defined(STM32F4XX) || defined(STM32F7XX)
+#if !defined(STMUART_H)
+#define STMUART_H
+
+#if defined(STM32F4XX)
+#include "stm32f4xx.h"
+#elif defined(STM32F7XX)
+#include "stm32f7xx.h"
+#endif
+
+const uint16_t BUFFER_SIZE = 2048U; //needs to be a power of 2 !
+const uint16_t BUFFER_MASK = BUFFER_SIZE - 1;
+
+class CSTMUARTFIFO {
+public:
+  CSTMUARTFIFO() :
+  m_head(0U),
+  m_tail(0U)
+  {
+  }
+
+  void put(uint8_t data)
+  {
+    m_buffer[BUFFER_MASK & (m_head++)] = data;
+  }
+
+  uint8_t get()
+  {
+    return m_buffer[BUFFER_MASK & (m_tail++)];
+  }
+
+  void reset()
+  {
+    m_tail = 0U;
+    m_head = 0U;
+  }
+
+  bool isEmpty()
+  {
+    return m_tail == m_head;
+  }
+
+  bool isFull()
+  {
+    return ((m_head + 1U) & BUFFER_MASK) == (m_tail & BUFFER_MASK);
+  }
+
+private:
+  volatile uint8_t  m_buffer[BUFFER_SIZE];
+  volatile uint16_t m_head;
+  volatile uint16_t m_tail;
+};
+
+class CSTMUART {
+public:
+  CSTMUART();
+  void init(USART_TypeDef* usart);
+  void write(const uint8_t * data, uint16_t length);
+  uint8_t read();
+  void handleIRQ();
+  void flush();
+  uint16_t available();
+  uint16_t availableForWrite();
+
+private:
+  USART_TypeDef * m_usart;
+  CSTMUARTFIFO    m_rxFifo;
+  CSTMUARTFIFO    m_txFifo;
+};
+
+#endif
+#endif

--- a/SerialPort.cpp
+++ b/SerialPort.cpp
@@ -602,7 +602,7 @@ void CSerialPort::setMode(MMDVM_STATE modemState)
 
 void CSerialPort::start()
 {
-  beginInt(1U, 115200);
+  beginInt(1U, SERIAL_SPEED);
 
 #if defined(SERIAL_REPEATER)
   beginInt(3U, 9600);

--- a/SerialPort.h
+++ b/SerialPort.h
@@ -23,6 +23,10 @@
 #include "Globals.h"
 #include "RingBuffer.h"
 
+#if !defined(SERIAL_SPEED)
+#define SERIAL_SPEED 115200
+#endif
+
 
 class CSerialPort {
 public:

--- a/SerialSTM.cpp
+++ b/SerialSTM.cpp
@@ -83,7 +83,7 @@ void InitUSART1(int speed)
    GPIO_InitStructure.GPIO_PuPd  = GPIO_PuPd_UP;
    GPIO_InitStructure.GPIO_Mode  = GPIO_Mode_AF;
    GPIO_InitStructure.GPIO_Pin   = GPIO_Pin_9 | GPIO_Pin_10; //  Tx | Rx
-   GPIO_InitStructure.GPIO_Speed = GPIO_High_Speed;
+   GPIO_InitStructure.GPIO_Speed = GPIO_Fast_Speed;
    GPIO_Init(GPIOA, &GPIO_InitStructure);
 
    // Configure USART baud rate

--- a/SerialSTM.cpp
+++ b/SerialSTM.cpp
@@ -39,9 +39,7 @@ UART5  - TXD PC12 - RXD PD2 (Discovery, MMDVM-Pi, MMDVM-Pi F722 board, MMDVM-F4M
 
 #if defined(STM32F4XX) || defined(STM32F7XX)
 
-#define TX_SERIAL_FIFO_SIZE 512U
-#define RX_SERIAL_FIFO_SIZE 512U
-
+#include "STMUART.h"
 extern "C" {
    void USART1_IRQHandler();
    void USART2_IRQHandler();
@@ -52,111 +50,12 @@ extern "C" {
 /* ************* USART1 ***************** */
 #if defined(STM32F4_PI) || defined(STM32F4_F4M) || defined(STM32F722_F7M) || defined(STM32F722_PI) || defined(STM32F722_RPT_HAT) || defined(STM32F4_DVM) || (defined(STM32F4_NUCLEO) && defined(STM32F4_NUCLEO_ARDUINO_HEADER)) || defined(DRCC_DVM)
 
-volatile uint8_t  TXSerialfifo1[TX_SERIAL_FIFO_SIZE];
-volatile uint8_t  RXSerialfifo1[RX_SERIAL_FIFO_SIZE];
-volatile uint16_t TXSerialfifohead1, TXSerialfifotail1;
-volatile uint16_t RXSerialfifohead1, RXSerialfifotail1;
 
-// Init queues
-void TXSerialfifoinit1()
-{
-   TXSerialfifohead1 = 0U;
-   TXSerialfifotail1 = 0U;
-}
-
-void RXSerialfifoinit1()
-{
-   RXSerialfifohead1 = 0U;
-   RXSerialfifotail1 = 0U;
-}
-
-// How full is queue
-// TODO decide if how full or how empty is preferred info to return
-uint16_t TXSerialfifolevel1()
-{
-   uint32_t tail = TXSerialfifotail1;
-   uint32_t head = TXSerialfifohead1;
-
-   if (tail > head)
-      return TX_SERIAL_FIFO_SIZE + head - tail;
-   else
-      return head - tail;
-}
-
-uint16_t RXSerialfifolevel1()
-{
-   uint32_t tail = RXSerialfifotail1;
-   uint32_t head = RXSerialfifohead1;
-
-   if (tail > head)
-      return RX_SERIAL_FIFO_SIZE + head - tail;
-   else
-      return head - tail;
-}
-
-// Flushes the transmit shift register
-// warning: this call is blocking
-void TXSerialFlush1()
-{
-   // wait until the TXE shows the shift register is empty
-   while (USART_GetITStatus(USART1, USART_FLAG_TXE))
-      ;
-}
-
-uint8_t TXSerialfifoput1(uint8_t next)
-{
-   if (TXSerialfifolevel1() < TX_SERIAL_FIFO_SIZE) {
-      TXSerialfifo1[TXSerialfifohead1] = next;
-
-      TXSerialfifohead1++;
-      if (TXSerialfifohead1 >= TX_SERIAL_FIFO_SIZE)
-         TXSerialfifohead1 = 0U;
-
-      // make sure transmit interrupts are enabled as long as there is data to send
-      USART_ITConfig(USART1, USART_IT_TXE, ENABLE);
-      return 1U;
-   } else {
-      return 0U; // signal an overflow occurred by returning a zero count
-   }
-}
+static CSTMUART m_USART1;
 
 void USART1_IRQHandler()
 {
-   uint8_t c;
-
-   if (USART_GetITStatus(USART1, USART_IT_RXNE)) {
-      c = (uint8_t) USART_ReceiveData(USART1);
-
-      if (RXSerialfifolevel1() < RX_SERIAL_FIFO_SIZE) {
-         RXSerialfifo1[RXSerialfifohead1] = c;
-
-         RXSerialfifohead1++;
-         if (RXSerialfifohead1 >= RX_SERIAL_FIFO_SIZE)
-            RXSerialfifohead1 = 0U;
-      } else {
-         // TODO - do something if rx fifo is full?
-      }
-
-      USART_ClearITPendingBit(USART1, USART_IT_RXNE);
-   }
-
-   if (USART_GetITStatus(USART1, USART_IT_TXE)) {
-      c = 0U;
-
-      if (TXSerialfifohead1 != TXSerialfifotail1) { // if the fifo is not empty
-         c = TXSerialfifo1[TXSerialfifotail1];
-
-         TXSerialfifotail1++;
-         if (TXSerialfifotail1 >= TX_SERIAL_FIFO_SIZE)
-            TXSerialfifotail1 = 0U;
-
-         USART_SendData(USART1, c);
-      } else { // if there's no more data to transmit then turn off TX interrupts
-         USART_ITConfig(USART1, USART_IT_TXE, DISABLE);
-      }
-
-      USART_ClearITPendingBit(USART1, USART_IT_TXE);
-   }
+  m_USART1.handleIRQ();
 }
 
 void InitUSART1(int speed)
@@ -184,7 +83,7 @@ void InitUSART1(int speed)
    GPIO_InitStructure.GPIO_PuPd  = GPIO_PuPd_UP;
    GPIO_InitStructure.GPIO_Mode  = GPIO_Mode_AF;
    GPIO_InitStructure.GPIO_Pin   = GPIO_Pin_9 | GPIO_Pin_10; //  Tx | Rx
-   GPIO_InitStructure.GPIO_Speed = GPIO_Fast_Speed;
+   GPIO_InitStructure.GPIO_Speed = GPIO_High_Speed;
    GPIO_Init(GPIOA, &GPIO_InitStructure);
 
    // Configure USART baud rate
@@ -201,41 +100,7 @@ void InitUSART1(int speed)
 
    USART_ITConfig(USART1, USART_IT_RXNE, ENABLE);
 
-   // initialize the fifos
-   TXSerialfifoinit1();
-   RXSerialfifoinit1();
-}
-
-uint8_t AvailUSART1()
-{
-   if (RXSerialfifolevel1() > 0U)
-      return 1U;
-   else
-      return 0U;
-}
-
-int AvailForWriteUSART1()
-{
-   return TX_SERIAL_FIFO_SIZE - TXSerialfifolevel1();
-}
-
-uint8_t ReadUSART1()
-{
-   uint8_t data_c = RXSerialfifo1[RXSerialfifotail1];
-
-   RXSerialfifotail1++;
-   if (RXSerialfifotail1 >= RX_SERIAL_FIFO_SIZE)
-      RXSerialfifotail1 = 0U;
-
-   return data_c;
-}
-
-void WriteUSART1(const uint8_t* data, uint16_t length)
-{
-   for (uint16_t i = 0U; i < length; i++)
-      TXSerialfifoput1(data[i]);
-
-   USART_ITConfig(USART1, USART_IT_TXE, ENABLE);
+   m_USART1.init(USART1);
 }
 
 #endif
@@ -243,111 +108,12 @@ void WriteUSART1(const uint8_t* data, uint16_t length)
 /* ************* USART2 ***************** */
 #if defined(STM32F4_NUCLEO) || defined(STM32F4_RPT_HAT_TGO) || defined(DRCC_DVM)
 
-volatile uint8_t  TXSerialfifo2[TX_SERIAL_FIFO_SIZE];
-volatile uint8_t  RXSerialfifo2[RX_SERIAL_FIFO_SIZE];
-volatile uint16_t TXSerialfifohead2, TXSerialfifotail2;
-volatile uint16_t RXSerialfifohead2, RXSerialfifotail2;
+static CSTMUART m_USART2;
 
-// Init queues
-void TXSerialfifoinit2()
-{
-   TXSerialfifohead2 = 0U;
-   TXSerialfifotail2 = 0U;
-}
-
-void RXSerialfifoinit2()
-{
-   RXSerialfifohead2 = 0U;
-   RXSerialfifotail2 = 0U;
-}
-
-// How full is queue
-// TODO decide if how full or how empty is preferred info to return
-uint16_t TXSerialfifolevel2()
-{
-   uint32_t tail = TXSerialfifotail2;
-   uint32_t head = TXSerialfifohead2;
-
-   if (tail > head)
-      return TX_SERIAL_FIFO_SIZE + head - tail;
-   else
-      return head - tail;
-}
-
-uint16_t RXSerialfifolevel2()
-{
-   uint32_t tail = RXSerialfifotail2;
-   uint32_t head = RXSerialfifohead2;
-
-   if (tail > head)
-      return RX_SERIAL_FIFO_SIZE + head - tail;
-   else
-      return head - tail;
-}
-
-// Flushes the transmit shift register
-// warning: this call is blocking
-void TXSerialFlush2()
-{
-   // wait until the TXE shows the shift register is empty
-   while (USART_GetITStatus(USART2, USART_FLAG_TXE))
-      ;
-}
-
-uint8_t TXSerialfifoput2(uint8_t next)
-{
-   if (TXSerialfifolevel2() < TX_SERIAL_FIFO_SIZE) {
-      TXSerialfifo2[TXSerialfifohead2] = next;
-
-      TXSerialfifohead2++;
-      if (TXSerialfifohead2 >= TX_SERIAL_FIFO_SIZE)
-         TXSerialfifohead2 = 0U;
-
-      // make sure transmit interrupts are enabled as long as there is data to send
-      USART_ITConfig(USART2, USART_IT_TXE, ENABLE);
-      return 1U;
-   } else {
-      return 0U; // signal an overflow occurred by returning a zero count
-   }
-}
 
 void USART2_IRQHandler()
 {
-   uint8_t c;
-
-   if (USART_GetITStatus(USART2, USART_IT_RXNE)) {
-      c = (uint8_t) USART_ReceiveData(USART2);
-
-      if (RXSerialfifolevel2() < RX_SERIAL_FIFO_SIZE) {
-         RXSerialfifo2[RXSerialfifohead2] = c;
-
-         RXSerialfifohead2++;
-         if (RXSerialfifohead2 >= RX_SERIAL_FIFO_SIZE)
-            RXSerialfifohead2 = 0U;
-      } else {
-         // TODO - do something if rx fifo is full?
-      }
-
-      USART_ClearITPendingBit(USART2, USART_IT_RXNE);
-   }
-
-   if (USART_GetITStatus(USART2, USART_IT_TXE)) {
-      c = 0U;
-
-      if (TXSerialfifohead2 != TXSerialfifotail2) { // if the fifo is not empty
-         c = TXSerialfifo2[TXSerialfifotail2];
-
-         TXSerialfifotail2++;
-         if (TXSerialfifotail2 >= TX_SERIAL_FIFO_SIZE)
-            TXSerialfifotail2 = 0U;
-
-         USART_SendData(USART2, c);
-      } else { // if there's no more data to transmit then turn off TX interrupts
-         USART_ITConfig(USART2, USART_IT_TXE, DISABLE);
-      }
-
-      USART_ClearITPendingBit(USART2, USART_IT_TXE);
-   }
+   m_USART2.handleIRQ();
 }
 
 void InitUSART2(int speed)
@@ -392,41 +158,7 @@ void InitUSART2(int speed)
 
    USART_ITConfig(USART2, USART_IT_RXNE, ENABLE);
 
-   // initialize the fifos
-   TXSerialfifoinit2();
-   RXSerialfifoinit2();
-}
-
-uint8_t AvailUSART2()
-{
-   if (RXSerialfifolevel2() > 0U)
-      return 1U;
-   else
-      return 0U;
-}
-
-int AvailForWriteUSART2()
-{
-   return TX_SERIAL_FIFO_SIZE - TXSerialfifolevel2();
-}
-
-uint8_t ReadUSART2()
-{
-   uint8_t data_c = RXSerialfifo2[RXSerialfifotail2];
-
-   RXSerialfifotail2++;
-   if (RXSerialfifotail2 >= RX_SERIAL_FIFO_SIZE)
-      RXSerialfifotail2 = 0U;
-
-   return data_c;
-}
-
-void WriteUSART2(const uint8_t* data, uint16_t length)
-{
-   for (uint16_t i = 0U; i < length; i++)
-      TXSerialfifoput2(data[i]);
-
-   USART_ITConfig(USART2, USART_IT_TXE, ENABLE);
+   m_USART2.init(USART2);
 }
 
 #endif
@@ -434,111 +166,11 @@ void WriteUSART2(const uint8_t* data, uint16_t length)
 /* ************* USART3 ***************** */
 #if defined(STM32F4_DISCOVERY) || defined(STM32F7_NUCLEO)
 
-volatile uint8_t  TXSerialfifo3[TX_SERIAL_FIFO_SIZE];
-volatile uint8_t  RXSerialfifo3[RX_SERIAL_FIFO_SIZE];
-volatile uint16_t TXSerialfifohead3, TXSerialfifotail3;
-volatile uint16_t RXSerialfifohead3, RXSerialfifotail3;
-
-// Init queues
-void TXSerialfifoinit3()
-{
-   TXSerialfifohead3 = 0U;
-   TXSerialfifotail3 = 0U;
-}
-
-void RXSerialfifoinit3()
-{
-   RXSerialfifohead3 = 0U;
-   RXSerialfifotail3 = 0U;
-}
-
-// How full is queue
-// TODO decide if how full or how empty is preferred info to return
-uint16_t TXSerialfifolevel3()
-{
-   uint32_t tail = TXSerialfifotail3;
-   uint32_t head = TXSerialfifohead3;
-
-   if (tail > head)
-      return TX_SERIAL_FIFO_SIZE + head - tail;
-   else
-      return head - tail;
-}
-
-uint16_t RXSerialfifolevel3()
-{
-   uint32_t tail = RXSerialfifotail3;
-   uint32_t head = RXSerialfifohead3;
-
-   if (tail > head)
-      return RX_SERIAL_FIFO_SIZE + head - tail;
-   else
-      return head - tail;
-}
-
-// Flushes the transmit shift register
-// warning: this call is blocking
-void TXSerialFlush3()
-{
-   // wait until the TXE shows the shift register is empty
-   while (USART_GetITStatus(USART3, USART_FLAG_TXE))
-      ;
-}
-
-uint8_t TXSerialfifoput3(uint8_t next)
-{
-   if (TXSerialfifolevel3() < TX_SERIAL_FIFO_SIZE) {
-      TXSerialfifo3[TXSerialfifohead3] = next;
-
-      TXSerialfifohead3++;
-      if (TXSerialfifohead3 >= TX_SERIAL_FIFO_SIZE)
-         TXSerialfifohead3 = 0U;
-
-      // make sure transmit interrupts are enabled as long as there is data to send
-      USART_ITConfig(USART3, USART_IT_TXE, ENABLE);
-      return 1U;
-   } else {
-      return 0U; // signal an overflow occurred by returning a zero count
-   }
-}
+static CSTMUART m_USART3;
 
 void USART3_IRQHandler()
 {
-   uint8_t c;
-
-   if (USART_GetITStatus(USART3, USART_IT_RXNE)) {
-      c = (uint8_t) USART_ReceiveData(USART3);
-
-      if (RXSerialfifolevel3() < RX_SERIAL_FIFO_SIZE) {
-         RXSerialfifo3[RXSerialfifohead3] = c;
-
-         RXSerialfifohead3++;
-         if (RXSerialfifohead3 >= RX_SERIAL_FIFO_SIZE)
-            RXSerialfifohead3 = 0U;
-      } else {
-         // TODO - do something if rx fifo is full?
-      }
-
-      USART_ClearITPendingBit(USART3, USART_IT_RXNE);
-   }
-
-   if (USART_GetITStatus(USART3, USART_IT_TXE)) {
-      c = 0U;
-
-      if (TXSerialfifohead3 != TXSerialfifotail3) { // if the fifo is not empty
-         c = TXSerialfifo3[TXSerialfifotail3];
-
-         TXSerialfifotail3++;
-         if (TXSerialfifotail3 >= TX_SERIAL_FIFO_SIZE)
-            TXSerialfifotail3 = 0U;
-
-         USART_SendData(USART3, c);
-      } else { // if there's no more data to transmit then turn off TX interrupts
-         USART_ITConfig(USART3, USART_IT_TXE, DISABLE);
-      }
-
-      USART_ClearITPendingBit(USART3, USART_IT_TXE);
-   }
+   m_USART3.handleIRQ();
 }
 
 #if defined(STM32F7_NUCLEO)
@@ -600,41 +232,7 @@ void InitUSART3(int speed)
 
    USART_ITConfig(USART3, USART_IT_RXNE, ENABLE);
 
-   // initialize the fifos
-   TXSerialfifoinit3();
-   RXSerialfifoinit3();
-}
-
-uint8_t AvailUSART3()
-{
-   if (RXSerialfifolevel3() > 0U)
-      return 1U;
-   else
-      return 0U;
-}
-
-int AvailForWriteUSART3()
-{
-   return TX_SERIAL_FIFO_SIZE - TXSerialfifolevel3();
-}
-
-uint8_t ReadUSART3()
-{
-   uint8_t data_c = RXSerialfifo3[RXSerialfifotail3];
-
-   RXSerialfifotail3++;
-   if (RXSerialfifotail3 >= RX_SERIAL_FIFO_SIZE)
-      RXSerialfifotail3 = 0U;
-
-   return data_c;
-}
-
-void WriteUSART3(const uint8_t* data, uint16_t length)
-{
-   for (uint16_t i = 0U; i < length; i++)
-      TXSerialfifoput3(data[i]);
-
-   USART_ITConfig(USART3, USART_IT_TXE, ENABLE);
+   m_USART3.init(USART3);
 }
 
 #endif
@@ -642,111 +240,11 @@ void WriteUSART3(const uint8_t* data, uint16_t length)
 /* ************* UART5 ***************** */
 #if !(defined(STM32F4_NUCLEO) && defined(STM32F4_NUCLEO_ARDUINO_HEADER))
 
-volatile uint8_t  TXSerialfifo5[TX_SERIAL_FIFO_SIZE];
-volatile uint8_t  RXSerialfifo5[RX_SERIAL_FIFO_SIZE];
-volatile uint16_t TXSerialfifohead5, TXSerialfifotail5;
-volatile uint16_t RXSerialfifohead5, RXSerialfifotail5;
-
-// Init queues
-void TXSerialfifoinit5()
-{
-   TXSerialfifohead5 = 0U;
-   TXSerialfifotail5 = 0U;
-}
-
-void RXSerialfifoinit5()
-{
-   RXSerialfifohead5 = 0U;
-   RXSerialfifotail5 = 0U;
-}
-
-// How full is queue
-// TODO decide if how full or how empty is preferred info to return
-uint16_t TXSerialfifolevel5()
-{
-   uint32_t tail = TXSerialfifotail5;
-   uint32_t head = TXSerialfifohead5;
-
-   if (tail > head)
-      return TX_SERIAL_FIFO_SIZE + head - tail;
-   else
-      return head - tail;
-}
-
-uint16_t RXSerialfifolevel5()
-{
-   uint32_t tail = RXSerialfifotail5;
-   uint32_t head = RXSerialfifohead5;
-
-   if (tail > head)
-      return RX_SERIAL_FIFO_SIZE + head - tail;
-   else
-      return head - tail;
-}
-
-// Flushes the transmit shift register
-// warning: this call is blocking
-void TXSerialFlush5()
-{
-   // wait until the TXE shows the shift register is empty
-   while (USART_GetITStatus(UART5, USART_FLAG_TXE))
-      ;
-}
-
-uint8_t TXSerialfifoput5(uint8_t next)
-{
-   if (TXSerialfifolevel5() < TX_SERIAL_FIFO_SIZE) {
-      TXSerialfifo5[TXSerialfifohead5] = next;
-
-      TXSerialfifohead5++;
-      if (TXSerialfifohead5 >= TX_SERIAL_FIFO_SIZE)
-         TXSerialfifohead5 = 0U;
-
-      // make sure transmit interrupts are enabled as long as there is data to send
-      USART_ITConfig(UART5, USART_IT_TXE, ENABLE);
-      return 1U;
-   } else {
-      return 0U; // signal an overflow occurred by returning a zero count
-   }
-}
+static CSTMUART m_UART5;
 
 void UART5_IRQHandler()
 {
-   uint8_t c;
-
-   if (USART_GetITStatus(UART5, USART_IT_RXNE)) {
-      c = (uint8_t) USART_ReceiveData(UART5);
-
-      if (RXSerialfifolevel5() < RX_SERIAL_FIFO_SIZE) {
-         RXSerialfifo5[RXSerialfifohead5] = c;
-
-         RXSerialfifohead5++;
-         if (RXSerialfifohead5 >= RX_SERIAL_FIFO_SIZE)
-            RXSerialfifohead5 = 0U;
-      } else {
-         // TODO - do something if rx fifo is full?
-      }
-
-      USART_ClearITPendingBit(UART5, USART_IT_RXNE);
-   }
-
-   if (USART_GetITStatus(UART5, USART_IT_TXE)) {
-      c = 0U;
-
-      if (TXSerialfifohead5 != TXSerialfifotail5) { // if the fifo is not empty
-         c = TXSerialfifo5[TXSerialfifotail5];
-
-         TXSerialfifotail5++;
-         if (TXSerialfifotail5 >= TX_SERIAL_FIFO_SIZE)
-            TXSerialfifotail5 = 0U;
-
-         USART_SendData(UART5, c);
-      } else { // if there's no more data to transmit then turn off TX interrupts
-      USART_ITConfig(UART5, USART_IT_TXE, DISABLE);
-      }
-
-      USART_ClearITPendingBit(UART5, USART_IT_TXE);
-   }
+   m_UART5.handleIRQ();
 }
 
 void InitUART5(int speed)
@@ -795,41 +293,7 @@ void InitUART5(int speed)
 
    USART_ITConfig(UART5, USART_IT_RXNE, ENABLE);
 
-   // initialize the fifos
-   TXSerialfifoinit5();
-   RXSerialfifoinit5();
-}
-
-uint8_t AvailUART5()
-{
-   if (RXSerialfifolevel5() > 0U)
-      return 1U;
-   else
-      return 0U;
-}
-
-int AvailForWriteUART5()
-{
-   return TX_SERIAL_FIFO_SIZE - TXSerialfifolevel5();
-}
-
-uint8_t ReadUART5()
-{
-   uint8_t data_c = RXSerialfifo5[RXSerialfifotail5];
-
-   RXSerialfifotail5++;
-   if (RXSerialfifotail5 >= RX_SERIAL_FIFO_SIZE)
-      RXSerialfifotail5 = 0U;
-
-   return data_c;
-}
-
-void WriteUART5(const uint8_t* data, uint16_t length)
-{
-   for (uint16_t i = 0U; i < length; i++)
-      TXSerialfifoput5(data[i]);
-
-   USART_ITConfig(UART5, USART_IT_TXE, ENABLE);
+   m_UART5.init(UART5);
 }
 
 #endif
@@ -868,21 +332,21 @@ int CSerialPort::availableInt(uint8_t n)
    switch (n) {
       case 1U:
          #if defined(STM32F4_DISCOVERY) || defined(STM32F7_NUCLEO)
-         return AvailUSART3();
+         return m_USART3.availble();//AvailUSART3();
          #elif defined(STM32F4_PI) || defined(STM32F4_F4M) || defined(STM32F722_PI) || defined(STM32F722_F7M) || defined(STM32F722_RPT_HAT) || defined(STM32F4_DVM)
-         return AvailUSART1();
+         return m_USART1.available();//AvailUSART1();
          #elif defined(STM32F4_NUCLEO) || defined(STM32F4_RPT_HAT_TGO)
-         return AvailUSART2();
+         return m_USART2.available();//AvailUSART2();
          #elif defined(DRCC_DVM)
-         return AvailUSART1();
+         return m_USART1.available();//AvailUSART1();
          #endif
       case 3U:
          #if defined(STM32F4_NUCLEO) && defined(STM32F4_NUCLEO_ARDUINO_HEADER)
-         return AvailUSART1();
+         return m_USART1.available(); //AvailUSART1();
          #elif defined(DRCC_DVM)
-         return AvailUSART2();
+         return m_USART2.available(); //AvailUSART2();
          #else
-         return AvailUART5();
+         return m_UART5.available();//AvailUART5();
          #endif
       default:
          return 0;
@@ -894,21 +358,21 @@ int CSerialPort::availableForWriteInt(uint8_t n)
    switch (n) {
       case 1U:
          #if defined(STM32F4_DISCOVERY) || defined(STM32F7_NUCLEO)
-         return AvailForWriteUSART3();
+         return m_USART3.availableForWrite(); //AvailForWriteUSART3();
          #elif defined(STM32F4_PI) || defined(STM32F4_F4M) || defined(STM32F722_PI) || defined(STM32F722_F7M) || defined(STM32F722_RPT_HAT) || defined(STM32F4_DVM)
-         return AvailForWriteUSART1();
+         return m_USART1.availableForWrite(); //AvailForWriteUSART1();
          #elif defined(STM32F4_NUCLEO) || defined(STM32F4_RPT_HAT_TGO)
-         return AvailForWriteUSART2();
+         return m_USART2.availableForWrite();//AvailForWriteUSART2();
          #elif defined(DRCC_DVM)
-         return AvailForWriteUSART1();
+         return m_USART1.availableForWrite();//AvailForWriteUSART1();
          #endif
       case 3U:
          #if defined(STM32F4_NUCLEO) && defined(STM32F4_NUCLEO_ARDUINO_HEADER)
-         return AvailForWriteUSART1();
+         return m_USART1.availableForWrite(); //AvailForWriteUSART1();
          #elif defined(DRCC_DVM)
-         AvailForWriteUSART2();
+         return m_USART2.availableForWrite();//AvailForWriteUSART2();
          #else
-         return AvailForWriteUART5();
+         return m_UART5.availableForWrite();//AvailForWriteUART5();
          #endif
       default:
          return 0;
@@ -920,21 +384,21 @@ uint8_t CSerialPort::readInt(uint8_t n)
    switch (n) {
       case 1U:
          #if defined(STM32F4_DISCOVERY) || defined(STM32F7_NUCLEO)
-         return ReadUSART3();
+         return m_USART3.read();//ReadUSART3();
          #elif defined(STM32F4_PI) || defined(STM32F4_F4M) || defined(STM32F722_PI) || defined(STM32F722_F7M) || defined(STM32F722_RPT_HAT) || defined(STM32F4_DVM)
-         return ReadUSART1();
+         return m_USART1.read();//ReadUSART1();
          #elif defined(STM32F4_NUCLEO) || defined(STM32F4_RPT_HAT_TGO)
-         return ReadUSART2();
+         return m_USART2.read();//ReadUSART2();
          #elif defined(DRCC_DVM)
-         return ReadUSART1();
+         return m_USART1.read();//ReadUSART1();
          #endif
       case 3U:
          #if defined(STM32F4_NUCLEO) && defined(STM32F4_NUCLEO_ARDUINO_HEADER)
-         return ReadUSART1();
+         return m_USART1.read();//ReadUSART1();
          #elif defined(DRCC_DVM)
-         return ReadUSART2();
+         return m_USART2.read();//ReadUSART2();
          #else
-         return ReadUART5();
+         return m_UART5.read();//ReadUART5();
          #endif
       default:
          return 0U;
@@ -946,36 +410,36 @@ void CSerialPort::writeInt(uint8_t n, const uint8_t* data, uint16_t length, bool
    switch (n) {
       case 1U:
          #if defined(STM32F4_DISCOVERY) || defined(STM32F7_NUCLEO)
-         WriteUSART3(data, length);
+         m_USART3.write(data, length); //WriteUSART3(data, length);
          if (flush)
-            TXSerialFlush3();
+            m_USART3.flush();//TXSerialFlush3();
          #elif defined(STM32F4_PI) || defined(STM32F4_F4M) || defined(STM32F722_PI) || defined(STM32F722_F7M) || defined(STM32F722_RPT_HAT) || defined(STM32F4_DVM)
-         WriteUSART1(data, length);
+         m_USART1.write(data, length);//WriteUSART1(data, length);
          if (flush)
-            TXSerialFlush1();
+            m_USART1.flush();//TXSerialFlush1();
          #elif defined(STM32F4_NUCLEO) || defined(STM32F4_RPT_HAT_TGO)
-         WriteUSART2(data, length);
+         m_USART2.write(data, length);//WriteUSART2(data, length);
          if (flush)
-            TXSerialFlush2();
+            m_USART2.flush();//TXSerialFlush2();
          #elif defined(DRCC_DVM)
-         WriteUSART1(data, length);
+         m_USART1.write(data, length);//WriteUSART1(data, length);
          if (flush)
-            TXSerialFlush1();
+            m_USART1.flush();//TXSerialFlush1();
          #endif
          break;
       case 3U:
          #if defined(STM32F4_NUCLEO) && defined(STM32F4_NUCLEO_ARDUINO_HEADER)
-         WriteUSART1(data, length);
+         m_USART1.write(data, length); //WriteUSART1(data, length);
          if (flush)
-            TXSerialFlush1();
+            m_USART1.flush();
          #elif defined(DRCC_DVM)
-         WriteUSART2(data, length);
+         m_USART2.write(data, length);//WriteUSART2(data, length);
          if (flush)
-            TXSerialFlush2();
+            m_USART2.flush();//TXSerialFlush2();
          #else
-         WriteUART5(data, length);
+         m_UART5.write(data, length);//WriteUART5(data, length);
          if (flush)
-            TXSerialFlush5();
+            m_UART5.flush();//TXSerialFlush5();
          #endif
          break;
       default:

--- a/Tools/FMGenerateFilterCoefficients.py
+++ b/Tools/FMGenerateFilterCoefficients.py
@@ -17,30 +17,30 @@ f2 = 2700
 rp = 0.2
 
 # scaling factor in bits, do not change !
-q = 0
+q = 15
 # scaling factor as facor...
 scaling_factor = 2**q
 
 # let's generate a sequence of 2nd order IIR filters
 sos = signal.cheby1(3,rp,[f1, f2],'bandpass', output='sos', fs=fs)
-#sos = signal.cheby1(1, rp, 2122, 'lowpass', output='sos', fs=fs) #deemphasis filter
+#os = signal.cheby1(4, rp, f2, 'lowpass', output='sos', fs=fs) #deemphasis filter
 #sos = signal.cheby1(1, rp, 2122, 'highpass', output='sos', fs=fs) #deemphasis filter
 
-#sos = np.round((sos) * scaling_factor)
+sosrounded = np.round((sos) * scaling_factor)
 
 # print coefficients
-for biquad in sos:
+for biquad in sosrounded:
     for coeff in biquad:
-        #print(int(coeff),",",sep="",end="")
-        print((coeff),",",sep="",end="")
+        print(int(coeff),",",sep="",end="")
+        #print((coeff),",",sep="",end="")
     print("")
 
 # plot the frequency response
 b,a = signal.sos2tf(sos)
-w,h = signal.freqz(b,a)
+w,h = signal.freqz(b,a, worN=2048)
 pl.plot(w/np.pi/2*fs,20*np.log(np.abs(h)))
 pl.xlabel('frequency/Hz');
 pl.ylabel('gain/dB');
-pl.ylim(top=1,bottom=-20);
+pl.ylim(top=1,bottom=-30);
 pl.xlim(left=250, right=12000);
 pl.show()


### PR DESCRIPTION
- improve IO.buffer filling from FM::process
- Clean up STM UART copy paste code
- Add compile options for serial speed, if not defined defaults to 115200
- Improve filter generation script
- Fix sample packing 