### PR TITLE
Added pin definition for FM mode LED (WA0EDA Boards)

### DIFF
--- a/IO.cpp
+++ b/IO.cpp
@@ -152,8 +152,8 @@ void CIO::selfTest()
   }
 
 #if defined(MODE_LEDS)
-  setDStarInt(true);
-  setDMRInt(false);
+  setDStarInt(false);
+  setDMRInt(true);
   setYSFInt(false);
   setP25Int(false);
   setNXDNInt(false);
@@ -161,7 +161,7 @@ void CIO::selfTest()
   setFMInt(false);
 
   delayInt(250);
-  setDMRInt(true);
+  setDStarInt(true);
 
   delayInt(250);
   setYSFInt(true);

--- a/IO.cpp
+++ b/IO.cpp
@@ -152,8 +152,8 @@ void CIO::selfTest()
   }
 
 #if defined(MODE_LEDS)
-  setDStarInt(false);
-  setDMRInt(true);
+  setDStarInt(true);
+  setDMRInt(false);
   setYSFInt(false);
   setP25Int(false);
   setNXDNInt(false);
@@ -161,7 +161,7 @@ void CIO::selfTest()
   setFMInt(false);
 
   delayInt(250);
-  setDStarInt(true);
+  setDMRInt(true);
 
   delayInt(250);
   setYSFInt(true);

--- a/pins/pins_f4_stm32eda.h
+++ b/pins/pins_f4_stm32eda.h
@@ -33,6 +33,7 @@ DSTAR    PB6    output
 DMR      PB5    output
 YSF      PB7    output
 POCSAG   PC10   output
+FM       PC11   output
 
 RX       PB0    analog input
 RSSI     PB1    analog input
@@ -81,6 +82,10 @@ EXT_CLK  PA15   input
 #define PIN_POCSAG        GPIO_Pin_10
 #define PORT_POCSAG       GPIOC
 #define RCC_Per_POCSAG    RCC_AHB1Periph_GPIOC
+
+#define PIN_FM            GPIO_Pin_11
+#define PORT_FM           GPIOC
+#define RCC_Per_FM        RCC_AHB1Periph_GPIOC
 
 #define PIN_EXT_CLK       GPIO_Pin_15
 #define SRC_EXT_CLK       GPIO_PinSource15


### PR DESCRIPTION
In anticipation of a new hardware revision with additional mode LEDs, a pin definition for an FM mode LED was assigned.