### PR TITLE
YSF pictures can go through modem 

### DIFF
--- a/YSFRX.cpp
+++ b/YSFRX.cpp
@@ -36,7 +36,7 @@ const uint8_t NOAVEPTR = 99U;
 
 const uint16_t NOENDPTR = 9999U;
 
-const unsigned int MAX_SYNC_FRAMES = 4U + 1U;
+const unsigned int MAX_SYNC_FRAMES = 1U + 1U;
 
 CYSFRX::CYSFRX() :
 m_state(YSFRXS_NONE),


### PR DESCRIPTION
Lower MAX_SYNC_FRAMES to 2, so decoder can recover and Yaesu pictures can pass through the modem without problem.