### PR TITLE
Detect full 48 bits of last data frame in a D-Star transmission

### DIFF
--- a/DStarRX.h
+++ b/DStarRX.h
@@ -41,6 +41,7 @@ private:
   bool         m_prev;
   DSRX_STATE   m_rxState;
   uint32_t     m_patternBuffer;
+  uint64_t     m_patternBuffer64;
   uint8_t      m_rxBuffer[100U];
   unsigned int m_rxBufferBits;
   unsigned int m_dataBits;


### PR DESCRIPTION
While testing new support for DV Fast Data in https://github.com/g4klx/MMDVMHost/pull/667, I ran across a particular image that reliably generated a bit sequence that the MDMVM firmware interpreted as an end-of-transmission.  I dug a bit and discovered that MMDVM only matches on 32 bits of the last data frame instead of the full 48 bits.

(I referenced http://www.arrl.org/files/file/D-STAR.pdf section 2.1.2, item (6))

I'm not convinced that this implementation is the best version of this change, but it does work for me.  I tested this patch on both a ZUMSpot (by making the same change against https://github.com/juribeparada/MMDVM_HS) and a Raspberry Pi with a ZUM Radio MMDVM-Pi rev 1.0 board, and the test image no longer generated an early EOT on either system.