### PR TITLE
Fix AX25 DAC overflow error message

### DIFF
--- a/AX25TX.cpp
+++ b/AX25TX.cpp
@@ -160,7 +160,7 @@ void CAX25TX::writeBit(bool b)
       m_tablePtr += 11U;
     }
 
-    buffer[i] = value;
+    buffer[i] = value >> 1;
 
     if (m_tablePtr >= AUDIO_TABLE_LEN)
       m_tablePtr -= AUDIO_TABLE_LEN;


### PR DESCRIPTION
The AX25 sine value ranges from 0-4095, and inside io.write() will perform the calculation (value * q15_t(txLevel) >> 15) which may exceed 4096 and cause the DAC Overflow error