### PR TITLE
WA0EDA STM32-DVM-MTR2K v2.0d FM LED -and- Armbian + AllWinner H2/H3 UART speed

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -70,6 +70,7 @@
 // #define SERIAL_SPEED 115200 // Suitable for most older boards (Arduino Due, STM32F1_POG, etc). External FM will NOT work with this!
 // #define SERIAL_SPEED 230400 // Only works on newer boards like fast M4, M7, Teensy 3.x. External FM might work with this
 #define SERIAL_SPEED 460800	// Only works on newer boards like fast M4, M7, Teensy 3.x. External FM should work with this
+//#define SERIAL_SPEED 500000  // Used with newer boards and Armbian on AllWinner SOCs (H2, H3) that do not support 460800
 
 // Use pins to output the current mode via LEDs
 #define MODE_LEDS

--- a/pins/pins_f4_stm32eda.h
+++ b/pins/pins_f4_stm32eda.h
@@ -33,7 +33,7 @@ DSTAR    PB6    output
 DMR      PB5    output
 YSF      PB7    output
 POCSAG   PC10   output
-FM       PC11   output
+FM       PB14   output
 
 RX       PB0    analog input
 RSSI     PB1    analog input
@@ -83,9 +83,9 @@ EXT_CLK  PA15   input
 #define PORT_POCSAG       GPIOC
 #define RCC_Per_POCSAG    RCC_AHB1Periph_GPIOC
 
-#define PIN_FM            GPIO_Pin_11
-#define PORT_FM           GPIOC
-#define RCC_Per_FM        RCC_AHB1Periph_GPIOC
+#define PIN_FM            GPIO_Pin_14
+#define PORT_FM           GPIOB
+#define RCC_Per_FM        RCC_AHB1Periph_GPIOB
 
 #define PIN_EXT_CLK       GPIO_Pin_15
 #define SRC_EXT_CLK       GPIO_PinSource15


### PR DESCRIPTION
Adding a (commented) section in Config.h compile for 500000 UART speed to support the WA0EDA MODEMs and others that use Armbian + AllWinner H2/H3 SOC that does not support 4600800.

Adding support for FM LED on the WA0EDA STM-DVM-MTR2K v2.0d