### PR TITLE
Added option to configure Serial Repeater baud rate 

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -100,6 +100,9 @@
 // Use the modem as a serial repeater for Nextion displays
 #define SERIAL_REPEATER
 
+// Set the baud rate of the modem serial repeater for Nextion displays
+#define SERIAL_REPEATER_BAUD_RATE 9600
+
 // Use the modem as an I2C repeater for OLED displays
 // #define I2C_REPEATER
 

--- a/SerialPort.cpp
+++ b/SerialPort.cpp
@@ -896,7 +896,11 @@ void CSerialPort::start()
   beginInt(1U, SERIAL_SPEED);
 
 #if defined(SERIAL_REPEATER)
-  beginInt(3U, 9600);
+  #if defined(SERIAL_REPEATER_BAUD_RATE)
+    beginInt(3U, SERIAL_REPEATER_BAUD_RATE);
+  #else
+    beginInt(3U, 9600);
+  #endif
 #endif
 #if defined(I2C_REPEATER)
   beginInt(10U, 9600);


### PR DESCRIPTION
Existing code was hard coded to set the serial repeater baud rate to 9600.  This code change adds a SERIAL_REPEATER_BAUD_RATE define in the Config.h file, and sets the serial repeater baud rate to that user definable speed.  This will allow a 115,200 baud rate to be set for those using HS Nextion screen layouts that require the higher baud rate.