### PR TITLE
Fix several small bugs: STM UART repeater port, FM noise squelch, Due FM LED, DMR trunking state

### DIFF
--- a/DMRTX.cpp
+++ b/DMRTX.cpp
@@ -84,7 +84,8 @@ m_frameCount(0U),
 m_abortCount(),
 m_abort(),
 m_controlChannel(false),
-m_trunking(false)
+m_trunking(false),
+m_colorCode(0U)
 {
   ::memset(m_modState, 0x00U, 16U * sizeof(q15_t));
 
@@ -227,6 +228,12 @@ uint8_t CDMRTX::writeAloha(const uint8_t* data, uint16_t length)
     return 4U;
 
   ::memcpy(m_aloha, data, length);
+
+  // Stamp the slot type with the current colour code so that the result
+  // doesn't depend on the ordering of the ALOHA and SET_CONFIG commands.
+  CDMRSlotType slotType;
+  slotType.encode(m_colorCode, DT_CSBK, m_aloha);
+
   m_controlChannel = true;
 
   return 0U;
@@ -386,7 +393,7 @@ void CDMRTX::createCACH(uint8_t txSlotIndex, uint8_t rxSlotIndex)
         ::memcpy(m_shortLC, EMPTY_SHORT_LC, 12U);
     } else {
       ::memcpy(m_shortLC, m_newShortLC, 12U);
-	}
+    }
   }
 
   ::memcpy(m_poBuffer, m_shortLC + m_cachPtr, 3U);
@@ -426,6 +433,8 @@ void CDMRTX::createCACH(uint8_t txSlotIndex, uint8_t rxSlotIndex)
 
 void CDMRTX::setColorCode(uint8_t colorCode)
 {
+  m_colorCode = colorCode;
+
   if (m_trunking)
     ::memcpy(m_idle, TERMINATOR_DATA, DMR_FRAME_LENGTH_BYTES);
   else
@@ -458,6 +467,9 @@ uint32_t CDMRTX::getFrameCount()
 void CDMRTX::setTrunking(bool trunking)
 {
   m_trunking = trunking;
+
+  if (!trunking)
+    m_controlChannel = false;
 }
 
 #endif

--- a/DMRTX.h
+++ b/DMRTX.h
@@ -83,6 +83,7 @@ private:
   bool                             m_abort[2U];
   bool                             m_controlChannel;
   bool                             m_trunking;
+  uint8_t                          m_colorCode;
 
   void createData(uint8_t slotIndex);
   void createCACH(uint8_t txSlotIndex, uint8_t rxSlotIndex);

--- a/FMNoiseSquelch.cpp
+++ b/FMNoiseSquelch.cpp
@@ -36,7 +36,8 @@ m_count(0U),
 m_q0(0),
 m_q1(0),
 m_state(false),
-m_validCount(0U)
+m_validCount(0U),
+m_invalidCount(0U)
 {
 
 }
@@ -127,6 +128,8 @@ void CFMNoiseSquelch::reset()
   m_q1 = 0;
   m_state = false;
   m_count = 0U;
+  m_validCount = 0U;
+  m_invalidCount = 0U;
 }
 
 #endif

--- a/IODue.cpp
+++ b/IODue.cpp
@@ -110,7 +110,7 @@ void CIO::initInt()
 #if !defined(USE_ALTERNATE_POCSAG_LEDS)
   pinMode(PIN_POCSAG, OUTPUT);
 #endif
-#if !defined(USE_ALTERNATE_POCSAG_LEDS)
+#if !defined(USE_ALTERNATE_FM_LEDS)
   pinMode(PIN_FM,     OUTPUT);
 #endif
 #endif

--- a/STMUART.cpp
+++ b/STMUART.cpp
@@ -61,7 +61,7 @@ void CSTMUART::handleIRQ()
   if (USART_GetITStatus(m_usart, USART_IT_RXNE)) {
     if(!m_rxFifo.isFull())
       m_rxFifo.put((uint8_t) USART_ReceiveData(m_usart));
-    USART_ClearITPendingBit(USART1, USART_IT_RXNE);
+    USART_ClearITPendingBit(m_usart, USART_IT_RXNE);
   }
 
   if (USART_GetITStatus(m_usart, USART_IT_TXE)) {
@@ -82,8 +82,12 @@ void CSTMUART::flush()
   if(m_usart == NULL)
     return;
 
-   // wait until the TXE shows the shift register is empty
-   while (USART_GetITStatus(m_usart, USART_FLAG_TXE))
+   // wait until the TX FIFO has drained
+   while (!m_txFifo.isEmpty())
+      ;
+
+   // wait until the TC flag shows the shift register is empty
+   while (USART_GetFlagStatus(m_usart, USART_FLAG_TC) == RESET)
       ;
 }
 

--- a/SerialPort.cpp
+++ b/SerialPort.cpp
@@ -745,7 +745,7 @@ void CSerialPort::setMode(MMDVM_STATE modemState)
       DEBUG1("Mode set to FM 20Khz Calibrate");
       break;
     case STATE_FMCAL25K:
-      DEBUG1("Mode set to FM 10Khz Calibrate");
+      DEBUG1("Mode set to FM 25Khz Calibrate");
       break;
     case STATE_FMCAL30K:
       DEBUG1("Mode set to FM 30Khz Calibrate");


### PR DESCRIPTION
A handful of small, independent bug fixes found by code inspection. Each is its own commit so anything unwanted can be dropped easily.

**STMUART.cpp — wrong USART in the IRQ handler, and a broken flush()**
- `handleIRQ()` cleared the RXNE pending bit on a hardcoded `USART1` instead of `m_usart`, so on boards whose repeater/display UART is not USART1 (Nucleo USART2, F767/Discovery USART3, UART5-based boards) the flag was cleared on the wrong peripheral. The TXE branch a few lines below already used `m_usart`.
- `flush()` passed a flag constant (`USART_FLAG_TXE`) to `USART_GetITStatus()` and spun *while* TXE was set — but TXE set means the data register is already empty, so the loop exited immediately with data still queued and shifting out. It now waits for the software TX FIFO to drain and then for the TC flag.

**FMNoiseSquelch.cpp — uninitialised hysteresis counter**
`m_invalidCount` was missing from the constructor initialiser list and is read in `process()`, so the squelch behaviour after power-up was indeterminate. `reset()` also cleared neither `m_validCount` nor `m_invalidCount`, leaking state across resets. Possibly related to some of the reported random FM squelch openings (#357 / #319 reporters may want to retest with this).

**IODue.cpp — FM mode LED pin guard**
The `pinMode()` for `PIN_FM` was guarded by `USE_ALTERNATE_POCSAG_LEDS` instead of `USE_ALTERNATE_FM_LEDS` (copy/paste); the Teensy version and `setFMInt()` in the same file use the FM macro.

**DMRTX.cpp — trunking state handling (follow-up to #358)**
- The CSBK slot type was only encoded into the ALOHA frame in `setColorCode()`, so with the usual command ordering (SET_CONFIG, then ALOHA later) the transmitted slot type depended entirely on the host-supplied bytes; the encode only took effect if a reconfigure happened after an ALOHA had already been received. The colour code is now remembered and the slot type is stamped in `writeAloha()` too, making the result order-independent.
- `m_controlChannel` was never cleared once set; disabling trunking now clears it so the host can stop control-channel transmission without a reboot.
- Also fixes a stray tab in `createCACH()`.

**SerialPort.cpp — FM 25kHz calibrate debug message said "10Khz".**

Build-tested with GCC 14.2.1 on the `pi` (STM32F4) and `pi-f722` (STM32F7) targets, which cover all modified files. One note rather than a change: the new `MMDVM_DMR_ALOHA` command and trunking config bit aren't detectable by hosts, but bumping `PROTOCOL_VERSION` would break MMDVMHost's version check, so that seems better handled as a coordinated change (e.g. a capability bit) if trunking support is to be discoverable.