### PR TITLE
Link mode ext audio gap

### DIFF
--- a/FM.cpp
+++ b/FM.cpp
@@ -27,14 +27,8 @@ const uint16_t FM_TX_BLOCK_SIZE = 100U;
 const uint16_t FM_SERIAL_BLOCK_SIZE = 80U;//this is the number of sample pairs to send over serial. One sample pair is 3bytes.
                                           //three times this value shall never exceed 252
 const uint16_t FM_SERIAL_BLOCK_SIZE_BYTES = FM_SERIAL_BLOCK_SIZE * 3U;
-
-// How long a link-mode external-audio underrun is tolerated before it is
-// treated as a real end of transmission (see linkStateMachine()). A gap
-// shorter than this is inaudible on its own; the PTT drop-and-rekey it
-// would otherwise trigger is not. Tune here if needed -- no other code
-// depends on this value.
-const uint16_t FM_LINK_EXT_GAP_MS = 60U;
-
+const uint16_t FM_LINK_EXT_GAP_MS = 60U;// How long a link-mode external-audio underrun is tolerated before it is
+                                        // treated as a real end of transmission (see linkStateMachine()).
 const uint8_t FS_LISTENING         = 0U;
 const uint8_t FS_KERCHUNK_RF       = 1U;
 const uint8_t FS_RELAYING_RF       = 2U;
@@ -259,7 +253,6 @@ void CFM::linkSamples(bool cos, q15_t* samples, uint8_t length)
 
   uint8_t i = 0U;
   for (; i < length; i++) {
-    // ARMv7-M has hardware integer division
     q15_t currentRFSample = q15_t((q31_t(samples[i]) << 8) / m_rxLevel);
 
     if (m_noiseSquelch)
@@ -267,8 +260,7 @@ void CFM::linkSamples(bool cos, q15_t* samples, uint8_t length)
 
     // Zero-initialized: getSample() leaves this untouched on underrun, and
     // with the ext-gap debounce below, m_extSignal can now stay true for a
-    // few samples past that point -- silence, not stack garbage, must be
-    // what gets played out to the modem in that window.
+    // few samples past that point
     q15_t currentExtSample = 0;
     bool inputExt = m_inputExtRB.getSample(currentExtSample);//always consume the external input data so it does not overflow
     inputExt = inputExt && m_extEnabled;
@@ -1272,9 +1264,9 @@ void CFM::linkStateMachine(bool validRFSignal, bool validExtSignal)
     // the very first bad sample, with zero debounce -- that is what
     // actually keys the transmitter off (IO::process() drops PTT the
     // instant the downstream TX buffer runs dry, see IO.cpp). A gap well
-    // under FM_LINK_EXT_GAP_MS is inaudible on its own; the PTT
-    // drop-and-rekey it triggers is not. Give it a short grace period
-    // instead, mirroring the RELAYING_EXT/RELAYING_WAIT_EXT pattern the
+    // under FM_LINK_EXT_GAP_MS is less offensive than the PTT
+    // drop-and-rekey it triggers. Give it a short grace period
+    // mirroring the RELAYING_EXT/RELAYING_WAIT_EXT pattern the
     // non-link duplex/simplex paths already use for exactly this
     // situation (see relayingExtStateDuplex()/relayingExtWaitStateDuplex()).
     if (!m_extGapTimer.isRunning()) {

--- a/FM.cpp
+++ b/FM.cpp
@@ -28,6 +28,13 @@ const uint16_t FM_SERIAL_BLOCK_SIZE = 80U;//this is the number of sample pairs t
                                           //three times this value shall never exceed 252
 const uint16_t FM_SERIAL_BLOCK_SIZE_BYTES = FM_SERIAL_BLOCK_SIZE * 3U;
 
+// How long a link-mode external-audio underrun is tolerated before it is
+// treated as a real end of transmission (see linkStateMachine()). A gap
+// shorter than this is inaudible on its own; the PTT drop-and-rekey it
+// would otherwise trigger is not. Tune here if needed -- no other code
+// depends on this value.
+const uint16_t FM_LINK_EXT_GAP_MS = 60U;
+
 const uint8_t FS_LISTENING         = 0U;
 const uint8_t FS_KERCHUNK_RF       = 1U;
 const uint8_t FS_RELAYING_RF       = 2U;
@@ -62,6 +69,7 @@ m_ackMinTimer(),
 m_ackDelayTimer(),
 m_hangTimer(),
 m_reverseTimer(),
+m_extGapTimer(),
 m_needReverse(false),
 m_filterStage1(  724,   1448,   724, 32768, -37895, 21352),//3rd order Cheby Filter 300 to 2700Hz, 0.2dB passband ripple, sampling rate 24kHz
 m_filterStage2(32768,      0,-32768, 32768, -50339, 19052),
@@ -85,6 +93,7 @@ m_rssiAccum(0U),
 m_rssiCount(0U)
 {
   m_reverseTimer.setTimeout(0U, 150U);
+  m_extGapTimer.setTimeout(0U, FM_LINK_EXT_GAP_MS);
 
   insertDelay(100U);
 }
@@ -250,13 +259,17 @@ void CFM::linkSamples(bool cos, q15_t* samples, uint8_t length)
 
   uint8_t i = 0U;
   for (; i < length; i++) {
-    // ARMv7-M has hardware integer division 
+    // ARMv7-M has hardware integer division
     q15_t currentRFSample = q15_t((q31_t(samples[i]) << 8) / m_rxLevel);
 
     if (m_noiseSquelch)
       cos = m_squelch.process(currentRFSample);
 
-    q15_t currentExtSample;
+    // Zero-initialized: getSample() leaves this untouched on underrun, and
+    // with the ext-gap debounce below, m_extSignal can now stay true for a
+    // few samples past that point -- silence, not stack garbage, must be
+    // what gets played out to the modem in that window.
+    q15_t currentExtSample = 0;
     bool inputExt = m_inputExtRB.getSample(currentExtSample);//always consume the external input data so it does not overflow
     inputExt = inputExt && m_extEnabled;
 
@@ -601,6 +614,7 @@ void CFM::clock(uint8_t length)
   m_ackDelayTimer.clock(length);
   m_hangTimer.clock(length);
   m_reverseTimer.clock(length);
+  m_extGapTimer.clock(length);
 }
 
 void CFM::listeningStateDuplex(bool validRFSignal, bool validExtSignal)
@@ -1231,6 +1245,12 @@ void CFM::linkStateMachine(bool validRFSignal, bool validExtSignal)
     m_extSignal = true;
   }
 
+  if (validExtSignal && m_extGapTimer.isRunning()) {
+    // Recovered before the gap timer committed to a real loss below --
+    // m_extSignal was never flipped, so there is nothing else to undo.
+    m_extGapTimer.stop();
+  }
+
   if (!validRFSignal && m_rfSignal) {
     io.setDecode(false);
     io.setADCDetection(false);
@@ -1248,14 +1268,28 @@ void CFM::linkStateMachine(bool validRFSignal, bool validExtSignal)
   }
 
   if (!validExtSignal && m_extSignal) {
-    if (!m_rfSignal) {
-      DEBUG1("State to LISTENING");
-      m_state = FS_LISTENING;
-      serial.writeFMStatus(m_state);
-    }
+    // A missed/late sample used to flip m_extSignal false right here, on
+    // the very first bad sample, with zero debounce -- that is what
+    // actually keys the transmitter off (IO::process() drops PTT the
+    // instant the downstream TX buffer runs dry, see IO.cpp). A gap well
+    // under FM_LINK_EXT_GAP_MS is inaudible on its own; the PTT
+    // drop-and-rekey it triggers is not. Give it a short grace period
+    // instead, mirroring the RELAYING_EXT/RELAYING_WAIT_EXT pattern the
+    // non-link duplex/simplex paths already use for exactly this
+    // situation (see relayingExtStateDuplex()/relayingExtWaitStateDuplex()).
+    if (!m_extGapTimer.isRunning()) {
+      m_extGapTimer.start();
+    } else if (m_extGapTimer.hasExpired()) {
+      if (!m_rfSignal) {
+        DEBUG1("State to LISTENING");
+        m_state = FS_LISTENING;
+        serial.writeFMStatus(m_state);
+      }
 
-    m_needReverse = true;
-    m_extSignal   = false;
+      m_needReverse = true;
+      m_extSignal   = false;
+      m_extGapTimer.stop();
+    }
   }
 }
 

--- a/FM.h
+++ b/FM.h
@@ -75,6 +75,7 @@ private:
   CFMTimer             m_ackDelayTimer;
   CFMTimer             m_hangTimer;
   CFMTimer             m_reverseTimer;
+  CFMTimer             m_extGapTimer;   // debounce for link-mode ext-audio underrun, see linkStateMachine()
   bool                 m_needReverse;
   CFMDirectFormI       m_filterStage1;
   CFMDirectFormI       m_filterStage2;


### PR DESCRIPTION
When LinkMode=1, MMDVM did not provide the silence buffer to cover gaps in the sample stream that it uses internally when LinkMode=0. This duplicates the same function for LinkMode=1, which can produce slight audio gaps, but is far better than the TX dropping and re-keying.